### PR TITLE
Use Test::Lib in tests

### DIFF
--- a/etc/bundles/NoGUI/Changes
+++ b/etc/bundles/NoGUI/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module Task::Biodiverse::NoGUI
 
+1.00012 2015-10-06
+    - Depend on Test::Lib in addition to rlib
+
 1.00011 2015-06-11
     - Fix a copy-paste error in the makefile which resulted in neither of
       Spreadsheet::ParseXLSX and Spreadsheet::XLSX being installed.

--- a/etc/bundles/NoGUI/Makefile.PL
+++ b/etc/bundles/NoGUI/Makefile.PL
@@ -35,6 +35,7 @@ WriteMakefile(
         "Clone" => "0.35",
         "Regexp::Common" => "0",
         "rlib" => "0",
+        "Test::Lib" => "0",
         "parent" => "0",
         "Readonly" => "0",
         "URI::Escape::XS" => "0",

--- a/etc/bundles/NoGUI/lib/Task/Biodiverse/NoGUI.pm
+++ b/etc/bundles/NoGUI/lib/Task/Biodiverse/NoGUI.pm
@@ -3,7 +3,7 @@ package Task::Biodiverse::NoGUI;
 use strict;
 use warnings;
 
-our $VERSION = '1.00011';
+our $VERSION = '1.00012';
 
 
 1;

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -7,7 +7,7 @@ use FindBin qw { $Bin };
 use File::Spec;
 use File::Find;
 
-use rlib;
+use Test::Lib;
 
 #  need to move GUI modules into their own test file
 BEGIN {

--- a/t/01-csv_guesswork.t
+++ b/t/01-csv_guesswork.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 
 use Test::More;
 use Test::Exception;

--- a/t/10-ElementProperties.t
+++ b/t/10-ElementProperties.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 
 use Test::More;
 use Test::Exception;

--- a/t/11-BaseData-import-spreadsheet.t
+++ b/t/11-BaseData-import-spreadsheet.t
@@ -11,7 +11,7 @@ use English qw { -no_match_vars };
 use Data::Dumper;
 use Path::Class;
 
-use rlib;
+use Test::Lib;
 
 use Data::Section::Simple qw(
     get_data_section

--- a/t/11-BaseData.t
+++ b/t/11-BaseData.t
@@ -11,7 +11,7 @@ use English qw { -no_match_vars };
 use Data::Dumper;
 use Path::Class;
 
-use rlib;
+use Test::Lib;
 
 use Data::Section::Simple qw(
     get_data_section

--- a/t/11-BaseData_clone_save_reload.t
+++ b/t/11-BaseData_clone_save_reload.t
@@ -11,7 +11,7 @@ use English qw { -no_match_vars };
 
 use Scalar::Util qw /blessed/;
 
-use rlib;
+use Test::Lib;
 
 local $| = 1;
 

--- a/t/11-BaseData_exclusions.t
+++ b/t/11-BaseData_exclusions.t
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 use English qw { -no_match_vars };
 
-use rlib;
+use Test::Lib;
 
 use Data::Section::Simple qw(
     get_data_section

--- a/t/11-BaseData_reorder_axes.t
+++ b/t/11-BaseData_reorder_axes.t
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 use English qw { -no_match_vars };
 
-use rlib;
+use Test::Lib;
 
 local $| = 1;
 

--- a/t/12-BaseStruct-export.t
+++ b/t/12-BaseStruct-export.t
@@ -8,7 +8,7 @@ use English qw { -no_match_vars };
 use Carp;
 use Scalar::Util qw /blessed/;
 
-use rlib;
+use Test::Lib;
 
 use Data::Section::Simple qw(
     get_data_section

--- a/t/12-BaseStruct.t
+++ b/t/12-BaseStruct.t
@@ -10,7 +10,7 @@ use 5.010;
 
 use English qw { -no_match_vars };
 
-use rlib;
+use Test::Lib;
 
 use Data::Section::Simple qw(
     get_data_section

--- a/t/13-Tree.t
+++ b/t/13-Tree.t
@@ -6,7 +6,7 @@ use warnings;
 use Carp;
 
 use FindBin qw/$Bin/;
-use rlib;
+use Test::Lib;
 use List::Util qw /first sum/;
 
 use Test::More;

--- a/t/20-Biodiverse_Statistics-descr.t
+++ b/t/20-Biodiverse_Statistics-descr.t
@@ -6,7 +6,7 @@ use warnings;
 use Test::More tests => 55;
 
 use lib 't/lib';
-use rlib;
+use Test::Lib;
 use Utils qw/is_between compare_hash_by_ranges/;
 
 use Benchmark;

--- a/t/20-Biodiverse_Statistics.t
+++ b/t/20-Biodiverse_Statistics.t
@@ -5,7 +5,7 @@ use English qw { -no_match_vars };
 
 use FindBin qw/$Bin/;
 
-use rlib;
+use Test::Lib;
 
 use Test::More;
 

--- a/t/21-ReadNexus.t
+++ b/t/21-ReadNexus.t
@@ -5,7 +5,7 @@ use English qw { -no_match_vars };
 use Carp;
 
 use FindBin qw/$Bin/;
-use rlib;
+use Test::Lib;
 
 #use Test::More tests => 35;
 use Test::More;

--- a/t/22-SpatialConditions2.t
+++ b/t/22-SpatialConditions2.t
@@ -7,7 +7,7 @@ use English qw{
     -no_match_vars
 };
 
-use rlib;
+use Test::Lib;
 use Test::More;
 
 use Biodiverse::BaseData;

--- a/t/22-SpatialConditions3.t
+++ b/t/22-SpatialConditions3.t
@@ -7,7 +7,7 @@ use English qw{
     -no_match_vars
 };
 
-use rlib;
+use Test::Lib;
 use Test::More;
 
 use Biodiverse::BaseData;

--- a/t/22-SpatialConditions4.t
+++ b/t/22-SpatialConditions4.t
@@ -8,7 +8,7 @@ use English qw{
     -no_match_vars
 };
 
-use rlib;
+use Test::Lib;
 use Test::More;
 
 use Biodiverse::BaseData;

--- a/t/22-SpatialConditions5.t
+++ b/t/22-SpatialConditions5.t
@@ -8,7 +8,7 @@ use English qw{
     -no_match_vars
 };
 
-use rlib;
+use Test::Lib;
 use Test::More;
 
 use Biodiverse::BaseData;

--- a/t/22-SpatialConditions_block_select.t
+++ b/t/22-SpatialConditions_block_select.t
@@ -6,7 +6,7 @@ use English qw { -no_match_vars };
 
 use FindBin qw/$Bin/;
 
-use rlib;
+use Test::Lib;
 use Scalar::Util qw /looks_like_number/;
 use Data::Dumper qw /Dumper/;
 #use Test::More tests => 255;

--- a/t/22-SpatialConditions_main.t
+++ b/t/22-SpatialConditions_main.t
@@ -6,7 +6,7 @@ use English qw { -no_match_vars };
 
 use FindBin qw/$Bin/;
 
-use rlib;
+use Test::Lib;
 use Scalar::Util qw /looks_like_number/;
 use Data::Dumper qw /Dumper/;
 #use Test::More tests => 255;

--- a/t/22-SpatialConditions_metadata.t
+++ b/t/22-SpatialConditions_metadata.t
@@ -9,7 +9,7 @@ use English qw{
 
 use Scalar::Util qw /reftype/;
 
-use rlib;
+use Test::Lib;
 use Test::More;
 
 use Biodiverse::BaseData;

--- a/t/22-SpatialConditions_rectangle.t
+++ b/t/22-SpatialConditions_rectangle.t
@@ -6,7 +6,7 @@ use English qw { -no_match_vars };
 
 use FindBin qw/$Bin/;
 
-use rlib;
+use Test::Lib;
 use Scalar::Util qw /looks_like_number/;
 use Data::Dumper qw /Dumper/;
 #use Test::More tests => 255;

--- a/t/22-SpatialConditions_side_in_line.t
+++ b/t/22-SpatialConditions_side_in_line.t
@@ -6,7 +6,7 @@ use English qw { -no_match_vars };
 
 use FindBin qw/$Bin/;
 
-use rlib;
+use Test::Lib;
 use Scalar::Util qw /looks_like_number/;
 use Data::Dumper qw /Dumper/;
 #use Test::More tests => 255;

--- a/t/22-SpatialConditions_side_left.t
+++ b/t/22-SpatialConditions_side_left.t
@@ -6,7 +6,7 @@ use English qw { -no_match_vars };
 
 use FindBin qw/$Bin/;
 
-use rlib;
+use Test::Lib;
 use Scalar::Util qw /looks_like_number/;
 use Data::Dumper qw /Dumper/;
 #use Test::More tests => 255;

--- a/t/22-SpatialConditions_side_right.t
+++ b/t/22-SpatialConditions_side_right.t
@@ -6,7 +6,7 @@ use English qw { -no_match_vars };
 
 use FindBin qw/$Bin/;
 
-use rlib;
+use Test::Lib;
 use Scalar::Util qw /looks_like_number/;
 use Data::Dumper qw /Dumper/;
 #use Test::More tests => 255;

--- a/t/23-Indices.t
+++ b/t/23-Indices.t
@@ -5,7 +5,7 @@ use warnings;
 use English qw { -no_match_vars };
 use Carp;
 
-use rlib;
+use Test::Lib;
 
 use Test::More;
 use Test::Exception;

--- a/t/24-Indices_element-properties-group.t
+++ b/t/24-Indices_element-properties-group.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_element-properties-label.t
+++ b/t/24-Indices_element-properties-label.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_element-properties-label_gistar_range_wtd.t
+++ b/t/24-Indices_element-properties-label_gistar_range_wtd.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::More;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_endemism.t
+++ b/t/24-Indices_endemism.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_hierarchical-labels.t
+++ b/t/24-Indices_hierarchical-labels.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_inter-event-interval-statistics.t
+++ b/t/24-Indices_inter-event-interval-statistics.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_lists-and-counts.t
+++ b/t/24-Indices_lists-and-counts.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_lists_and_counts_rank_relative_abundances.t
+++ b/t/24-Indices_lists_and_counts_rank_relative_abundances.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_matrix.t
+++ b/t/24-Indices_matrix.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_numeric-labels.t
+++ b/t/24-Indices_numeric-labels.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_phylocom.t
+++ b/t/24-Indices_phylocom.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_phylocom_nri_nti.t
+++ b/t/24-Indices_phylocom_nri_nti.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::More;
 use Biodiverse::Config;
 

--- a/t/24-Indices_phylogenetic-pd-endemism.t
+++ b/t/24-Indices_phylogenetic-pd-endemism.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_phylogenetic.t
+++ b/t/24-Indices_phylogenetic.t
@@ -10,7 +10,7 @@ local $ENV{BIODIVERSE_EXTENSIONS_IGNORE} = 1;
 
 my $generate_result_sets = 0;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 use List::Util qw /sum/;
 

--- a/t/24-Indices_phylogenetic_relative.t
+++ b/t/24-Indices_phylogenetic_relative.t
@@ -12,7 +12,7 @@ BEGIN {
     #$ENV{BIODIVERSE_EXTENSIONS_IGNORE} = 0;
 }
 
-use rlib;
+use Test::Lib;
 use Test::More;
 use Biodiverse::Config;
 use List::Util qw /sum/;

--- a/t/24-Indices_phylogenetic_turnover.t
+++ b/t/24-Indices_phylogenetic_turnover.t
@@ -10,7 +10,7 @@ local $ENV{BIODIVERSE_EXTENSIONS_IGNORE} = 1;
 
 my $generate_result_sets = 0;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 use List::Util qw /sum/;
 

--- a/t/24-Indices_rarity.t
+++ b/t/24-Indices_rarity.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_taxonomic-dissimilarity-and-comparison.t
+++ b/t/24-Indices_taxonomic-dissimilarity-and-comparison.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/24-Indices_turnover_with_empty_groups.t
+++ b/t/24-Indices_turnover_with_empty_groups.t
@@ -5,7 +5,7 @@ use warnings;
 
 local $| = 1;
 
-use rlib;
+use Test::Lib;
 use Test::Most;
 
 use Biodiverse::TestHelpers qw{

--- a/t/25-Matrix.t
+++ b/t/25-Matrix.t
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 
 use FindBin qw/$Bin/;
-use rlib;
+use Test::Lib;
 use Scalar::Util qw /blessed/;
 use File::Compare;
 

--- a/t/26-Cluster.t
+++ b/t/26-Cluster.t
@@ -8,7 +8,7 @@ use warnings;
 use Carp;
 
 use FindBin qw/$Bin/;
-use rlib;
+use Test::Lib;
 use List::Util qw /first/;
 use File::Temp qw /tempfile/;
 

--- a/t/26-RegionGrower.t
+++ b/t/26-RegionGrower.t
@@ -7,7 +7,7 @@ use warnings;
 use Carp;
 
 use FindBin qw/$Bin/;
-use rlib;
+use Test::Lib;
 use List::Util qw /first/;
 
 use English qw / -no_match_vars /;

--- a/t/27-Spatial.t
+++ b/t/27-Spatial.t
@@ -9,7 +9,7 @@ use warnings;
 use Carp;
 
 use FindBin qw/$Bin/;
-use rlib;
+use Test::Lib;
 
 use Test::More;
 

--- a/t/28-Randomisation.t
+++ b/t/28-Randomisation.t
@@ -7,7 +7,7 @@ use warnings;
 use Carp;
 
 use FindBin qw/$Bin/;
-use rlib;
+use Test::Lib;
 use List::Util qw /first sum0/;
 
 use Test::More;

--- a/t/30-Progress.t
+++ b/t/30-Progress.t
@@ -4,7 +4,7 @@ use warnings;
 use English qw / -no_match_vars /;
 
 use FindBin qw/$Bin/;
-use rlib;
+use Test::Lib;
 
 use Test::More tests => 2;
 use Test::NoWarnings;

--- a/xt/04-pod-coverage.t
+++ b/xt/04-pod-coverage.t
@@ -4,8 +4,6 @@ use Test::More;
 
 local $| = 1;
 
-use rlib;
-
 use English qw ( -no_match_vars );
 
 # Ensure a recent version of Test::Pod::Coverage

--- a/xt/mem_leak_tests/90-rand_mem_leaks_weaken.t
+++ b/xt/mem_leak_tests/90-rand_mem_leaks_weaken.t
@@ -4,8 +4,6 @@ use warnings;
 use Carp;
 use English qw ( -no_match_vars );
 
-use rlib;
-
 use Test::More;
 
 use Test::Weaken qw( leaks );

--- a/xt/mem_leak_tests/91-rand_mem_leaks.t
+++ b/xt/mem_leak_tests/91-rand_mem_leaks.t
@@ -2,9 +2,6 @@
 use strict;
 use warnings;
 
-
-use rlib;
-
 use File::Temp;
 
 local $| = 1;

--- a/xt/mem_leak_tests/92-rand_mem_leaks_mk2.t
+++ b/xt/mem_leak_tests/92-rand_mem_leaks_mk2.t
@@ -2,9 +2,6 @@
 use strict;
 use warnings;
 
-
-use rlib;
-
 use File::Temp;
 
 use Devel::Leak;

--- a/xt/mem_leak_tests/93-numlabels_mem_leaks.pl
+++ b/xt/mem_leak_tests/93-numlabels_mem_leaks.pl
@@ -13,7 +13,6 @@ use Scalar::Util qw /isweak/;
 use FindBin qw /$Bin/;
 use lib "$Bin/../../lib";
 use lib "$Bin/../../t/lib";
-use rlib;
 
 #use File::Temp qw /tempfile/;
 

--- a/xt/mem_leak_tests/93-rand_mem_leaks_mk3.pl
+++ b/xt/mem_leak_tests/93-rand_mem_leaks_mk3.pl
@@ -15,7 +15,6 @@ use Data::Section::Simple qw(get_data_section);
 use FindBin qw /$Bin/;
 use lib "$Bin/lib";
 use lib "$Bin/../t/lib";
-use rlib;
 
 use File::Temp qw /tempfile/;
 

--- a/xt/mem_leak_tests/93-rand_mem_leaks_mk3_with_tree.pl
+++ b/xt/mem_leak_tests/93-rand_mem_leaks_mk3_with_tree.pl
@@ -17,7 +17,6 @@ use Data::Section::Simple qw(get_data_section);
 use FindBin qw /$Bin/;
 use lib "$Bin/lib";
 use lib "$Bin/../t/lib";
-use rlib;
 
 use File::Temp qw /tempfile/;
 

--- a/xt/mem_leak_tests/93-rand_mem_leaks_weaken_object.t
+++ b/xt/mem_leak_tests/93-rand_mem_leaks_weaken_object.t
@@ -4,8 +4,6 @@ use warnings;
 use Carp;
 use English qw ( -no_match_vars );
 
-use rlib;
-
 use Test::More;
 
 use FindBin qw {$Bin};


### PR DESCRIPTION
This will allow moving tests deeper into subdirectories.
rlib stays as it is needed for xt/ and bin/.

The proper way to run tests now is 'prove -l t' so that
the uppermost lib/ is added to @INC by prove.

Fixes #569.