### PR TITLE
Fix bug in conversion to Ref::Util

### DIFF
--- a/lib/Biodiverse/GUI/Project.pm
+++ b/lib/Biodiverse/GUI/Project.pm
@@ -597,7 +597,7 @@ sub add_phylogeny {
     my $phylogenies = shift;
     my $no_select = shift;
     
-    if (is_arrayref($phylogenies)) {
+    if (!is_arrayref($phylogenies)) {
         $phylogenies = [$phylogenies];  #  make a scalar value an array
     }
 


### PR DESCRIPTION
When converting from ref ____ to is_arrayref, I missed a '!' in Project.pm, which broke tree imports. This fixes that issue. 

See https://github.com/shawnlaffan/biodiverse/commit/53fb2450c06510278f56d00fa959ebda4c5329c4#diff-eafa3a4ec94f973c7a23899085889bce for where error was introduced. 