### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A **discussion group** is at http://groups.google.com.au/group/biodiverse-users 
 
 To cite Biodiverse or acknowledge its use, use the following details, substituting the version of the application that you used for "Version 1.0".
 
-* Laffan, S.W., Lubarsky, E. & Rosauer, D.F. (2010) Biodiverse, a tool for the spatial analysis of biological and related diversity. [Ecography. Vol 33, 643-647 (Version 1.0)](http://dx.doi.org/10.1111/j.1600-0587.2010.06237.x).
+* Laffan, S.W., Lubarsky, E. & Rosauer, D.F. (2010) Biodiverse, a tool for the spatial analysis of biological and related diversity. [Ecography. Vol 33, 643-647 (Version 1.0)](https://doi.org/10.1111/j.1600-0587.2010.06237.x).
 
 An overview of the system is also provided in Dan Rosauer's talk at TDWG2008:
 

--- a/lib/Biodiverse/Indices/Endemism.pm
+++ b/lib/Biodiverse/Indices/Endemism.pm
@@ -142,7 +142,7 @@ sub get_metadata_calc_endemism_central {
                 . "but with local ranges calculated using both neighbour sets";
 
     my $ref = 'Crisp et al. (2001) J Biogeog. '
-              . 'http://dx.doi.org/10.1046/j.1365-2699.2001.00524.x ; '
+              . 'https://doi.org/10.1046/j.1365-2699.2001.00524.x ; '
               . 'Laffan and Crisp (2003) J Biogeog. '
               . 'http://www3.interscience.wiley.com/journal/118882020/abstract';
 
@@ -194,7 +194,7 @@ sub get_metadata_calc_endemism_central {
                                . 'best applied with a small window.',
                 lumper      => 0,
                 reference   => 'Slatyer et al. (2007) J. Biogeog '
-                               . 'http://dx.doi.org/10.1111/j.1365-2699.2006.01647.x',
+                               . 'https://doi.org/10.1111/j.1365-2699.2006.01647.x',
                 formula     => [
                     '= \sum_{t \in T} \frac {1} {R_t}',
                     ' where ',
@@ -386,7 +386,7 @@ sub metadata_for_calc_endemism_hier_part {
         description     => $descr,
         name            => "Endemism $endemism_type hierarchical partition",
         type            => 'Endemism',
-        reference       => 'Laffan et al. (2013) J Biogeog. http://dx.doi.org/10.1111/jbi.12001',
+        reference       => 'Laffan et al. (2013) J Biogeog. https://doi.org/10.1111/jbi.12001',
         formula         => $formula,
         pre_calc        => [
             "_calc_endemism_$endemism_type",
@@ -584,7 +584,7 @@ sub get_metadata_calc_endemism_whole {
                                . 'Useful if your data have sampling biases and '
                                . 'best applied with a small window.',
                 reference   => 'Slatyer et al. (2007) J. Biogeog '
-                               . 'http://dx.doi.org/10.1111/j.1365-2699.2006.01647.x',
+                               . 'https://doi.org/10.1111/j.1365-2699.2006.01647.x',
                 formula     => [
                     '= \sum_{t \in T} \frac {1} {R_t}',
                     ' where ',

--- a/lib/Biodiverse/Indices/GroupProperties.pm
+++ b/lib/Biodiverse/Indices/GroupProperties.pm
@@ -336,7 +336,7 @@ sub get_metadata_calc_gpprop_gistar {
     my $self = shift;
 
     my $desc = 'List of Getis-Ord Gi* statistics for each group property across both neighbour sets';
-    my $ref  = 'Getis and Ord (1992) Geographical Analysis. http://dx.doi.org/10.1111/j.1538-4632.1992.tb00261.x';
+    my $ref  = 'Getis and Ord (1992) Geographical Analysis. https://doi.org/10.1111/j.1538-4632.1992.tb00261.x';
 
     my %metadata = (
         description     => $desc,

--- a/lib/Biodiverse/Indices/Hierarchical_Labels.pm
+++ b/lib/Biodiverse/Indices/Hierarchical_Labels.pm
@@ -60,7 +60,7 @@ END_H_DESC
 ;
     
     my $ref = 'Jones and Laffan (2008) Trans Philol Soc '
-            . 'http://dx.doi.org/10.1111/j.1467-968X.2008.00209.x';
+            . 'https://doi.org/10.1111/j.1467-968X.2008.00209.x';
 
     my %metadata = (
         name            => 'Ratios of hierarchical labels',

--- a/lib/Biodiverse/Indices/Indices.pm
+++ b/lib/Biodiverse/Indices/Indices.pm
@@ -107,7 +107,7 @@ sub get_metadata_calc_redundancy {
         pre_calc        => 'calc_abc3',
         uses_nbr_lists  => 1,  #  how many sets of lists it must have
         reference       => 'Garcillan et al. (2003) J Veget. Sci. '
-                         . 'http://dx.doi.org/10.1111/j.1654-1103.2003.tb02174.x',
+                         . 'https://doi.org/10.1111/j.1654-1103.2003.tb02174.x',
         indices         => {
             REDUNDANCY_ALL  => {
                 description     => 'for both neighbour sets',
@@ -399,8 +399,8 @@ sub calc_jaccard {
 #        $self -> get_formula_explanation_ABC,
 #    ];
 #
-#    my $ref = 'Hayes, W.B. (1978) http://dx.doi.org/10.2307/1936649, '
-#              . 'McKenna (2003) http://dx.doi.org/10.1016/S1364-8152(02)00094-4';
+#    my $ref = 'Hayes, W.B. (1978) https://doi.org/10.2307/1936649, '
+#              . 'McKenna (2003) https://doi.org/10.1016/S1364-8152(02)00094-4';
 #    
 #    my %metadata = (
 #        name           => 'Fager',
@@ -450,7 +450,7 @@ sub get_metadata_calc_nestedness_resultant {
         type            => 'Taxonomic Dissimilarity and Comparison',
         uses_nbr_lists  => 2,  #  how many sets of lists it must have
         reference       => 'Baselga (2010) Glob Ecol Biogeog.  '
-                           . 'http://dx.doi.org/10.1111/j.1466-8238.2009.00490.x',
+                           . 'https://doi.org/10.1111/j.1466-8238.2009.00490.x',
         pre_calc        => [qw /calc_abc/],
         formula         => [
             '=\frac{ \left | B - C \right | }{ 2A + B + C } '
@@ -470,7 +470,7 @@ sub get_metadata_calc_nestedness_resultant {
 }
 
 #  nestedness-resultant dissimilarity
-#  from Baselga (2010) http://dx.doi.org/10.1111/j.1466-8238.2009.00490.x
+#  from Baselga (2010) https://doi.org/10.1111/j.1466-8238.2009.00490.x
 sub calc_nestedness_resultant {
     my $self = shift;
     my %args = @_;
@@ -730,7 +730,7 @@ sub get_metadata_calc_s2 {
         pre_calc        => 'calc_abc',
         uses_nbr_lists  => 2,  #  how many sets of lists it must have
         reference   => 'Lennon et al. (2001) J Animal Ecol.  '
-                        . 'http://dx.doi.org/10.1046/j.0021-8790.2001.00563.x',
+                        . 'https://doi.org/10.1046/j.0021-8790.2001.00563.x',
         formula     => [
             '= 1 - \frac{A}{A + min(B, C)}',
             $self -> get_formula_explanation_ABC,

--- a/lib/Biodiverse/Indices/LabelProperties.pm
+++ b/lib/Biodiverse/Indices/LabelProperties.pm
@@ -374,7 +374,7 @@ sub get_metadata_calc_lbprop_gistar {
     my $self = shift;
 
     my $desc = 'List of Getis-Ord Gi* statistic for each label property across both neighbour sets';
-    my $ref  = 'Getis and Ord (1992) Geographical Analysis. http://dx.doi.org/10.1111/j.1538-4632.1992.tb00261.x';
+    my $ref  = 'Getis and Ord (1992) Geographical Analysis. https://doi.org/10.1111/j.1538-4632.1992.tb00261.x';
 
     my %metadata = (
         description     => $desc,

--- a/lib/Biodiverse/Indices/LabelPropertiesRangeWtd.pm
+++ b/lib/Biodiverse/Indices/LabelPropertiesRangeWtd.pm
@@ -206,7 +206,7 @@ sub get_metadata_calc_lbprop_gistar_abc2 {
     my $self = shift;
 
     my $desc = 'List of Getis-Ord Gi* statistic for each label property across both neighbour sets (local range weighted)';
-    my $ref  = 'Getis and Ord (1992) Geographical Analysis. http://dx.doi.org/10.1111/j.1538-4632.1992.tb00261.x';
+    my $ref  = 'Getis and Ord (1992) Geographical Analysis. https://doi.org/10.1111/j.1538-4632.1992.tb00261.x';
 
     my %metadata = (
         description     => $desc,

--- a/lib/Biodiverse/Indices/Numeric_Labels.pm
+++ b/lib/Biodiverse/Indices/Numeric_Labels.pm
@@ -534,7 +534,7 @@ sub get_metadata_calc_num_labels_gistar {
     my $self = shift;
 
     my $desc = 'Getis-Ord Gi* statistic for numeric labels across both neighbour sets';
-    my $ref  = 'Getis and Ord (1992) Geographical Analysis. http://dx.doi.org/10.1111/j.1538-4632.1992.tb00261.x';
+    my $ref  = 'Getis and Ord (1992) Geographical Analysis. https://doi.org/10.1111/j.1538-4632.1992.tb00261.x';
 
     my %metadata = (
         description     => $desc,

--- a/lib/Biodiverse/Indices/PhyloCom.pm
+++ b/lib/Biodiverse/Indices/PhyloCom.pm
@@ -28,7 +28,7 @@ my $prng_class = 'Math::Random::MT::Auto';
 
 my $metadata_class = 'Biodiverse::Metadata::Indices';
 
-my $webb_et_al_ref = 'Webb et al. (2008) http://dx.doi.org/10.1093/bioinformatics/btn358';
+my $webb_et_al_ref = 'Webb et al. (2008) https://doi.org/10.1093/bioinformatics/btn358';
 
 
 my $nri_nti_expl_text = <<'END_NRI_NTI_EXPL_TEXT'

--- a/lib/Biodiverse/Indices/Phylogenetic.pm
+++ b/lib/Biodiverse/Indices/Phylogenetic.pm
@@ -51,7 +51,7 @@ sub get_metadata_calc_pd {
             PD              => {
                 cluster       => undef,
                 description   => 'Phylogenetic diversity',
-                reference     => 'Faith (1992) Biol. Cons. http://dx.doi.org/10.1016/0006-3207(92)91201-3',
+                reference     => 'Faith (1992) Biol. Cons. https://doi.org/10.1016/0006-3207(92)91201-3',
                 formula       => [
                     '= \sum_{c \in C} L_c',
                     ' where ',
@@ -488,9 +488,9 @@ sub get_metadata_calc_pe {
                             . 'trims the tree to exclude labels not in the '
                             . 'BaseData object.',
         name            => 'Phylogenetic Endemism',
-        reference       => 'Rosauer et al (2009) Mol. Ecol. http://dx.doi.org/10.1111/j.1365-294X.2009.04311.x'
-                         . '; Laity et al. (2015) http://dx.doi.org/10.1016/j.scitotenv.2015.04.113'
-                         . '; Laffan et al. (2016) http://dx.doi.org/10.1111/2041-210X.12513',
+        reference       => 'Rosauer et al (2009) Mol. Ecol. https://doi.org/10.1111/j.1365-294X.2009.04311.x'
+                         . '; Laity et al. (2015) https://doi.org/10.1016/j.scitotenv.2015.04.113'
+                         . '; Laffan et al. (2016) https://doi.org/10.1111/2041-210X.12513',
         type            => 'Phylogenetic Endemism Indices',
         pre_calc        => ['_calc_pe'],  
         uses_nbr_lists  => 1,  #  how many lists it must have
@@ -524,7 +524,7 @@ sub get_metadata_calc_pe_lists {
     my %metadata = (
         description     => 'Lists used in the Phylogenetic endemism (PE) calculations.',
         name            => 'Phylogenetic Endemism lists',
-        reference       => 'Rosauer et al (2009) Mol. Ecol. http://dx.doi.org/10.1111/j.1365-294X.2009.04311.x',
+        reference       => 'Rosauer et al (2009) Mol. Ecol. https://doi.org/10.1111/j.1365-294X.2009.04311.x',
         type            => 'Phylogenetic Endemism Indices', 
         pre_calc        => ['_calc_pe'],  
         uses_nbr_lists  => 1,
@@ -581,7 +581,7 @@ END_PEC_DESC
     my %metadata = (
         description     => $desc,
         name            => 'Phylogenetic Endemism central',
-        reference       => 'Rosauer et al (2009) Mol. Ecol. http://dx.doi.org/10.1111/j.1365-294X.2009.04311.x',
+        reference       => 'Rosauer et al (2009) Mol. Ecol. https://doi.org/10.1111/j.1365-294X.2009.04311.x',
         type            => 'Phylogenetic Endemism Indices',
         pre_calc        => [qw /_calc_pe _calc_phylo_abc_lists/],
         pre_calc_global => [qw /get_trimmed_tree/],
@@ -637,7 +637,7 @@ END_PEC_DESC
     my %metadata = (
         description     => $desc,
         name            => 'Phylogenetic Endemism central lists',
-        reference       => 'Rosauer et al (2009) Mol. Ecol. http://dx.doi.org/10.1111/j.1365-294X.2009.04311.x',
+        reference       => 'Rosauer et al (2009) Mol. Ecol. https://doi.org/10.1111/j.1365-294X.2009.04311.x',
         type            => 'Phylogenetic Endemism Indices',
         pre_calc        => [qw /_calc_pe _calc_phylo_abc_lists/],
         uses_nbr_lists  => 1,  #  how many lists it must have
@@ -1148,7 +1148,7 @@ EOD
     my %metadata = (
         description     => $description,
         name            => 'Phylogenetic Endemism single',
-        reference       => 'Rosauer et al (2009) Mol. Ecol. http://dx.doi.org/10.1111/j.1365-294X.2009.04311.x',
+        reference       => 'Rosauer et al (2009) Mol. Ecol. https://doi.org/10.1111/j.1365-294X.2009.04311.x',
         type            => 'Phylogenetic Endemism Indices',
         pre_calc        => ['_calc_pe'],
         pre_calc_global => ['get_trimmed_tree'],
@@ -1206,7 +1206,7 @@ sub get_metadata_calc_pd_endemism {
                         .  'It is the sum of the branch lengths restricted '
                         .  'to the neighbour sets.',
         name            => 'PD-Endemism',
-        reference       => 'See Faith (2004) Cons Biol.  http://dx.doi.org/10.1111/j.1523-1739.2004.00330.x',
+        reference       => 'See Faith (2004) Cons Biol.  https://doi.org/10.1111/j.1523-1739.2004.00330.x',
         type            => 'Phylogenetic Endemism Indices',
         pre_calc        => ['calc_pe_lists'],
         pre_calc_global => [qw /get_trimmed_tree/],
@@ -1269,7 +1269,7 @@ sub get_metadata__calc_pe {
     my %metadata = (
         description     => 'Phylogenetic endemism (PE) base calcs.',
         name            => 'Phylogenetic Endemism base calcs',
-        reference       => 'Rosauer et al (2009) Mol. Ecol. http://dx.doi.org/10.1111/j.1365-294X.2009.04311.x',
+        reference       => 'Rosauer et al (2009) Mol. Ecol. https://doi.org/10.1111/j.1365-294X.2009.04311.x',
         type            => 'Phylogenetic Endemism Indices',  #  keeps it clear of the other indices in the GUI
         pre_calc_global => [ qw /
             get_node_range_hash
@@ -1908,9 +1908,9 @@ sub get_metadata_calc_taxonomic_distinctness {
     };
     
     my $ref = 'Warwick & Clarke (1995) Mar Ecol Progr Ser. '
-            . 'http://dx.doi.org/10.3354/meps129301 ; '
+            . 'https://doi.org/10.3354/meps129301 ; '
             . 'Clarke & Warwick (2001) Mar Ecol Progr Ser. '
-            . 'http://dx.doi.org/10.3354/meps216265';
+            . 'https://doi.org/10.3354/meps216265';
     
     my %metadata = (
         description     => 'Taxonomic/phylogenetic distinctness and variation. '
@@ -1968,9 +1968,9 @@ sub get_metadata_calc_taxonomic_distinctness_binary {
     };
 
     my $ref = 'Warwick & Clarke (1995) Mar Ecol Progr Ser. '
-            . 'http://dx.doi.org/10.3354/meps129301 ; '
+            . 'https://doi.org/10.3354/meps129301 ; '
             . 'Clarke & Warwick (2001) Mar Ecol Progr Ser. '
-            . 'http://dx.doi.org/10.3354/meps216265';
+            . 'https://doi.org/10.3354/meps216265';
 
     my %metadata = (
         description     => 'Taxonomic/phylogenetic distinctness and variation '
@@ -2113,7 +2113,7 @@ sub get_metadata_calc_phylo_sorenson {
         name           =>  'Phylo Sorenson',
         type           =>  'Phylogenetic Turnover',  #  keeps it clear of the other indices in the GUI
         description    =>  "Sorenson phylogenetic dissimilarity between two sets of taxa, represented by spanning sets of branches\n",
-        reference      => 'Bryant et al. (2008) http://dx.doi.org/10.1073/pnas.0801920105',
+        reference      => 'Bryant et al. (2008) https://doi.org/10.1073/pnas.0801920105',
         pre_calc       =>  'calc_phylo_abc',
         uses_nbr_lists =>  2,  #  how many sets of lists it must have
         indices        => {
@@ -2157,7 +2157,7 @@ sub get_metadata_calc_phylo_jaccard {
         name           =>  'Phylo Jaccard',
         type           =>  'Phylogenetic Turnover',
         description    =>  "Jaccard phylogenetic dissimilarity between two sets of taxa, represented by spanning sets of branches\n",
-        reference      => 'Lozupone and Knight (2005) http://dx.doi.org/10.1128/AEM.71.12.8228-8235.2005',
+        reference      => 'Lozupone and Knight (2005) https://doi.org/10.1128/AEM.71.12.8228-8235.2005',
         pre_calc       =>  'calc_phylo_abc',
         uses_nbr_lists =>  2,  #  how many sets of lists it must have
         indices        => {
@@ -2481,11 +2481,11 @@ sub get_metadata_calc_phylo_aed_t {
         type            =>  'Phylogenetic Indices',
         pre_calc        => [qw /_calc_phylo_aed_t/],
         uses_nbr_lists  =>  1,
-        reference    => 'Cadotte & Davies (2010) http://dx.doi.org/10.1111/j.1472-4642.2010.00650.x',
+        reference    => 'Cadotte & Davies (2010) https://doi.org/10.1111/j.1472-4642.2010.00650.x',
         indices         => {
             PHYLO_AED_T => {
                 description  => $descr,
-                reference    => 'Cadotte & Davies (2010) http://dx.doi.org/10.1111/j.1472-4642.2010.00650.x',
+                reference    => 'Cadotte & Davies (2010) https://doi.org/10.1111/j.1472-4642.2010.00650.x',
             },
         },
     );
@@ -2509,18 +2509,18 @@ sub get_metadata_calc_phylo_aed_t_wtlists {
         type            =>  'Phylogenetic Indices',
         pre_calc        => [qw /_calc_phylo_aed_t/],
         uses_nbr_lists  =>  1,
-        reference    => 'Cadotte & Davies (2010) http://dx.doi.org/10.1111/j.1472-4642.2010.00650.x',
+        reference    => 'Cadotte & Davies (2010) https://doi.org/10.1111/j.1472-4642.2010.00650.x',
         indices         => {
             PHYLO_AED_T_WTLIST => {
                 description  => 'Abundance weighted ED per terminal taxon '
                               . '(the AED score of each taxon multiplied by its '
                               . 'abundance in the sample)',
-                reference    => 'Cadotte & Davies (2010) http://dx.doi.org/10.1111/j.1472-4642.2010.00650.x',
+                reference    => 'Cadotte & Davies (2010) https://doi.org/10.1111/j.1472-4642.2010.00650.x',
                 type         => 'list',
             },
             PHYLO_AED_T_WTLIST_P => {
                 description  => 'Proportional contribution of each terminal taxon to the AED_T score',
-                reference    => 'Cadotte & Davies (2010) http://dx.doi.org/10.1111/j.1472-4642.2010.00650.x',
+                reference    => 'Cadotte & Davies (2010) https://doi.org/10.1111/j.1472-4642.2010.00650.x',
                 type         => 'list',
             },
         },
@@ -2603,22 +2603,22 @@ sub get_metadata_calc_phylo_aed {
         pre_calc        => [qw /calc_abc/],
         pre_calc_global => [qw /get_aed_scores/],
         uses_nbr_lists  =>  1,
-        reference    => 'Cadotte & Davies (2010) http://dx.doi.org/10.1111/j.1472-4642.2010.00650.x',
+        reference    => 'Cadotte & Davies (2010) https://doi.org/10.1111/j.1472-4642.2010.00650.x',
         indices         => {
             PHYLO_AED_LIST => {
                 description  =>  'Abundance weighted ED per terminal label',
                 type         => 'list',
-                reference    => 'Cadotte & Davies (2010) http://dx.doi.org/10.1111/j.1472-4642.2010.00650.x',
+                reference    => 'Cadotte & Davies (2010) https://doi.org/10.1111/j.1472-4642.2010.00650.x',
             },
             PHYLO_ES_LIST => {
                 description  =>  'Equal splits partitioning of PD per terminal label',
                 type         => 'list',
-                reference    => 'Redding & Mooers (2006) http://dx.doi.org/10.1111%2Fj.1523-1739.2006.00555.x',
+                reference    => 'Redding & Mooers (2006) https://doi.org/10.1111%2Fj.1523-1739.2006.00555.x',
             },
             PHYLO_ED_LIST => {
                 description  =>  q{"Fair proportion" partitioning of PD per terminal label},
                 type         => 'list',
-                reference    => 'Isaac et al. (2007) http://dx.doi.org/10.1371/journal.pone.0000296',
+                reference    => 'Isaac et al. (2007) https://doi.org/10.1371/journal.pone.0000296',
             },
         },
     );

--- a/lib/Biodiverse/Indices/PhylogeneticRelative.pm
+++ b/lib/Biodiverse/Indices/PhylogeneticRelative.pm
@@ -32,7 +32,7 @@ sub get_metadata_calc_phylo_rpd1 {
                          . 'PD evenly distributed across terminals and where '
                          . 'ancestral nodes are collapsed to zero length.',
         name            => 'Relative Phylogenetic Diversity, type 1',
-        reference       => 'Mishler et al. (2014) http://dx.doi.org/10.1038/ncomms5473',
+        reference       => 'Mishler et al. (2014) https://doi.org/10.1038/ncomms5473',
         type            => 'Phylogenetic Indices (relative)',
         pre_calc        => [qw /calc_pd calc_labels_on_tree/],
         required_args   => ['tree_ref'],
@@ -96,7 +96,7 @@ sub get_metadata_calc_phylo_rpe1 {
                          . 'but with the same range per terminal and where '
                          . 'ancestral nodes are of zero length (as per RPD1).',
         name            => 'Relative Phylogenetic Endemism, type 1',
-        reference       => 'Mishler et al. (2014) http://dx.doi.org/10.1038/ncomms5473',
+        reference       => 'Mishler et al. (2014) https://doi.org/10.1038/ncomms5473',
         type            => 'Phylogenetic Indices (relative)',
         pre_calc        => [qw /calc_pe calc_endemism_whole_lists calc_labels_on_trimmed_tree/],
         pre_calc_global => ['get_trimmed_tree'],
@@ -159,7 +159,7 @@ sub get_metadata_calc_phylo_rpd2 {
                          . 'PD evenly distributed across all nodes '
                          . '(all branches are of equal length).',
         name            => 'Relative Phylogenetic Diversity, type 2',
-        reference       => 'Mishler et al. (2014) http://dx.doi.org/10.1038/ncomms5473',
+        reference       => 'Mishler et al. (2014) https://doi.org/10.1038/ncomms5473',
         type            => 'Phylogenetic Indices (relative)',
         pre_calc        => [qw /calc_pd calc_pd_node_list/],
         pre_calc_global => [qw/
@@ -234,7 +234,7 @@ sub get_metadata_calc_phylo_rpe_central {
                          . 'Same as RPE2 except it only uses the branches in the '
                          . 'first neighbour set when more than one is set.',
         name            => 'Relative Phylogenetic Endemism, central',
-        reference       => 'Mishler et al. (2014) http://dx.doi.org/10.1038/ncomms5473',
+        reference       => 'Mishler et al. (2014) https://doi.org/10.1038/ncomms5473',
         type            => 'Phylogenetic Indices (relative)',
         pre_calc        => [qw /calc_pe_central calc_pe_central_lists/],
         pre_calc_global => [qw /
@@ -292,7 +292,7 @@ sub get_metadata_calc_phylo_rpe2 {
                          . 'PE is calculated using a tree where all branches '
                          . 'are of equal length.',
         name            => 'Relative Phylogenetic Endemism, type 2',
-        reference       => 'Mishler et al. (2014) http://dx.doi.org/10.1038/ncomms5473',
+        reference       => 'Mishler et al. (2014) https://doi.org/10.1038/ncomms5473',
         type            => 'Phylogenetic Indices (relative)',
         pre_calc        => [qw /calc_pe calc_pe_lists/],
         pre_calc_global => [qw /


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old `dx` subdomain is being redirected, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to all static DOI links.

Cheers!