### PR TITLE
Feature data imports: use GetFeatureCount for progress dialogue

### DIFF
--- a/lib/Biodiverse/BaseData/Import.pm
+++ b/lib/Biodiverse/BaseData/Import.pm
@@ -1134,15 +1134,17 @@ sub import_data_shapefile {
             }
         }
 
+        #  not yet a Geo::GDAL::FFI exported method
         #my $shape_count = $layer->GetFeatureCount();
-        #  interim solution
-        my $shape_count = 0;
-        while ($layer->GetNextFeature) {
-            $shape_count++;
+        my $shape_count = Geo::GDAL::FFI::OGR_L_GetFeatureCount($$layer);
+        #  fallback
+        if ($shape_count < 0) {
+            $shape_count = 0;
+            $shape_count++ while $layer->GetNextFeature;
+            $layer->ResetReading;
         }
-        $layer->ResetReading;
         say "File has $shape_count shapes";
-        
+
         %fld_names = %fld_names{@field_names_used_lc};
 
         # iterate over shapes


### PR DESCRIPTION
The previous approach was a leftover from when GDAL did not support this method for shapefiles,
instead returning -1.

Support in GDAL was added some time ago.

The call can be updated when Geo::GDAL::FFI
provides a wrapped method.

Fixes #885 