### PR TITLE
Indices: Ensure branches are non-negative for most phylo calculations

### DIFF
--- a/lib/Biodiverse/Indices/PhyloCom.pm
+++ b/lib/Biodiverse/Indices/PhyloCom.pm
@@ -166,6 +166,7 @@ sub get_metadata_calc_phylo_mpd_mntd1 {
                          . 'along the tree.  Compares with '
                          . 'all other labels across both neighbour sets. ',
         name            => 'Phylogenetic and Nearest taxon distances, unweighted',
+        pre_conditions  => ['tree_branches_are_nonnegative'],
         %$submeta,
     );
 
@@ -200,6 +201,7 @@ sub get_metadata_calc_phylo_mpd_mntd2 {
                          . 'all other labels across both neighbour sets. '
                          . 'Weighted by sample counts',
         name            => 'Phylogenetic and Nearest taxon distances, local range weighted',
+        pre_conditions  => ['tree_branches_are_nonnegative'],
         %$submeta,
     );
 
@@ -234,6 +236,7 @@ sub get_metadata_calc_phylo_mpd_mntd3 {
                          . 'all other labels across both neighbour sets. '
                          . 'Weighted by sample counts (which currently must be integers)',
         name            => 'Phylogenetic and Nearest taxon distances, abundance weighted',
+        pre_conditions  => ['tree_branches_are_nonnegative'],
         %$submeta,
     );
 
@@ -1069,6 +1072,7 @@ sub get_metadata__calc_nri_nti_expected_values {
         pre_calc_global => $pre_calc_global,  
         required_args   => 'tree_ref',
         uses_nbr_lists  => 1,
+        pre_conditions  => ['tree_branches_are_nonnegative'],
     );
     
     return $metadata_class->new(\%metadata);

--- a/lib/Biodiverse/Indices/Phylogenetic.pm
+++ b/lib/Biodiverse/Indices/Phylogenetic.pm
@@ -432,6 +432,7 @@ sub get_metadata__calc_pd {
         pre_calc_global => [qw /get_path_length_cache set_path_length_cache_by_group_flag/],
         uses_nbr_lists  => 1,  #  how many lists it must have
         required_args   => {'tree_ref' => 1},
+        pre_conditions  => ['tree_branches_are_nonnegative'],
     );
 
     return $metadata_class->new(\%metadata);
@@ -717,6 +718,7 @@ sub get_metadata_calc_pe {
                 distribution => 'unit_interval',
             },
         },
+        pre_conditions  => ['tree_branches_are_nonnegative'],
     );
 
     return $metadata_class->new(\%metadata);
@@ -2041,14 +2043,15 @@ sub get_node_abundance_global {
 
 sub get_metadata_get_trimmed_tree {
     my %metadata = (
-        name            => 'get_trimmed_tree',
-        description     => 'Get a version of the tree trimmed to contain only labels in the basedata',
-        required_args   => 'tree_ref',
-        indices         => {
+        name           => 'get_trimmed_tree',
+        description    => 'Get a version of the tree trimmed to contain only labels in the basedata',
+        required_args  => 'tree_ref',
+        indices        => {
             trimmed_tree => {
                 description => 'Trimmed tree',
             },
         },
+        pre_conditions => ['tree_branches_are_nonnegative'],
     );
     return $metadata_class->new(\%metadata);
 }
@@ -2412,7 +2415,8 @@ sub get_metadata_calc_phylo_jaccard {
                 cluster_can_lump_zeroes => 1,
             }
         },
-        required_args => {'tree_ref' => 1}
+        required_args => {'tree_ref' => 1},
+        pre_conditions => ['tree_branches_are_nonnegative'],
     );
 
     return $metadata_class->new(\%metadata);
@@ -2613,6 +2617,7 @@ sub get_metadata__calc_phylo_abc_lists {
         pre_calc_global =>  [qw /get_trimmed_tree get_path_length_cache set_path_length_cache_by_group_flag/],
         uses_nbr_lists  =>  1,  #  how many sets of lists it must have
         required_args   => {tree_ref => 1},
+        pre_conditions  => ['tree_branches_are_nonnegative'],
     );
 
     return $metadata_class->new(\%metadata);
@@ -3161,6 +3166,20 @@ sub calc_phylo_abundance {
     );
 
     return wantarray ? %results : \%results;
+}
+
+
+sub tree_branches_are_nonnegative {
+    my ($self, %args) = @_;
+
+    my $tree_ref = $args{tree_ref};
+
+    #  This is used as a precondition which does not
+    #  handle prereqs, so let other parts of the
+    #  system handle missing args
+    return 1 if !$tree_ref;
+
+    $tree_ref->branches_are_nonnegative;
 }
 
 1;

--- a/lib/Biodiverse/Tree.pm
+++ b/lib/Biodiverse/Tree.pm
@@ -3736,6 +3736,20 @@ sub get_mean_nearest_neighbour_distance {
     return $mean;
 }
 
+sub branches_are_nonnegative {
+    my $self = shift;
+
+    state $cache_key = 'BRANCHES_ARE_NONNEGATIVE';
+    my $non_neg = $self->get_cached_value ($cache_key);
+
+    return $non_neg if defined $non_neg;
+
+    $non_neg = List::Util::all {$_->get_length >= 0} $self->get_node_refs;
+    $non_neg //= 0;
+    $self->set_cached_value($cache_key => $non_neg);
+
+    return $non_neg;
+}
 
 1;
 


### PR DESCRIPTION
Exceptions are those that return information about the tree, e.g. how many and which branches match the basedata.

Fixes #896 