### PR TITLE
More index optimisations

### DIFF
--- a/lib/Biodiverse/Indices.pm
+++ b/lib/Biodiverse/Indices.pm
@@ -1023,15 +1023,20 @@ sub aggregate_calc_lists_by_type {
         my @u_array = uniq @$array;
         if ($type eq 'pre_calc'
             and scalar @u_array
-            and any {$_ eq '_calc_abc_any'} @u_array
         ) {
-            #  move first /calc_abc[23]?/ to front so
-            #  _calc_abc_any can grab results
-            state $re = qr{^calc_abc\d?};
-            if ($u_array[0] !~ $re) {
-                my $iter = first_index {$_ =~ $re} @u_array;
-                if ($iter > 0) {
-                    unshift @u_array, splice @u_array, $iter, 1;
+            #  move first /calc_abc[23]/ to front so
+            #  calc_abc and _calc_abc_any can grab results
+            #  otherwise ensure calc_abc is at the front
+            #  for _calc_abc_any
+            state $re = qr{^calc_abc[23]};
+            my $iter23 = first_index {$_ =~ $re} @u_array;
+            if ($iter23 > 0) {
+                unshift @u_array, splice @u_array, $iter23, 1;
+            }
+            else {
+                my $iter1 = first_index {$_ eq 'calc_abc'} @u_array;
+                if ($iter1 > 0) {
+                    unshift @u_array, splice @u_array, $iter1, 1;
                 }
             }
         }

--- a/lib/Biodiverse/Indices.pm
+++ b/lib/Biodiverse/Indices.pm
@@ -1552,7 +1552,7 @@ sub run_dependencies {
     my %results;
     my %as_results_from;
     #  make sure this is new each iteration
-    $self->set_cached_value ($cache_name_local_results => \%as_results_from);
+    $self->set_param ($cache_name_local_results => \%as_results_from);
 
     foreach my $calc (@$calc_list) {
         my $calc_results;
@@ -1591,7 +1591,7 @@ sub run_dependencies {
     }
 
     #  We refresh each call above, but this ensures last one is cleaned up.
-    $self->delete_cached_value($cache_name_local_results);
+    $self->delete_param ($cache_name_local_results);
 
     if ( $type eq 'pre_calc_global' ) {
         $self->set_param( AS_RESULTS_FROM_GLOBAL => \%as_results_from_global );

--- a/lib/Biodiverse/Indices/Endemism.pm
+++ b/lib/Biodiverse/Indices/Endemism.pm
@@ -303,7 +303,7 @@ sub calc_endemism_central_hier_part {
     #  If we have no nbrs in set 2 then we are the same as the "whole" variant.
     #  So just grab its values if it has already been calculated.
     if (!keys %{$args{label_hash2}}) {
-        my $cache_hash = $self->get_cached_value('AS_RESULTS_FROM_LOCAL');
+        my $cache_hash = $self->get_param('AS_RESULTS_FROM_LOCAL');
         my $cached = $cache_hash->{calc_endemism_whole_hier_part};
         if ($cached) {
             my %remapped;
@@ -335,7 +335,7 @@ sub calc_endemism_whole_hier_part {
     #  If we have no nbrs in set 2 then we are the same as the "central" variant.
     #  So just grab its values if it has already been calculated.
     if (!keys %{$args{label_hash2}}) {
-        my $cache_hash = $self->get_cached_value('AS_RESULTS_FROM_LOCAL');
+        my $cache_hash = $self->get_param('AS_RESULTS_FROM_LOCAL');
         my $cached = $cache_hash->{calc_endemism_central_hier_part};
         if ($cached) {
             # say STDERR join ' ', sort keys %$cached;
@@ -586,7 +586,7 @@ sub _calc_endemism_central {
     #  If we have no nbrs in set 2 then we are the same as the "whole" variant.
     #  So just grab its values if it has already been calculated.
     if (!keys %{$args{label_hash2}}) {
-        my $cache_hash = $self->get_cached_value('AS_RESULTS_FROM_LOCAL');
+        my $cache_hash = $self->get_param('AS_RESULTS_FROM_LOCAL');
         my $cached = $cache_hash->{_calc_endemism_whole};
         return wantarray ? %$cached : $cached
             if $cached;
@@ -736,7 +736,7 @@ sub _calc_endemism_whole {
     #  If we have no nbrs in set 2 then we are the same as the "central" variant.
     #  So just grab its values if it has already been calculated.
     if (!keys %{$args{label_hash2}}) {
-        my $cache_hash = $self->get_cached_value('AS_RESULTS_FROM_LOCAL');
+        my $cache_hash = $self->get_param('AS_RESULTS_FROM_LOCAL');
         my $cached = $cache_hash->{_calc_endemism_central};
         return wantarray ? %$cached : $cached
           if $cached;

--- a/lib/Biodiverse/Indices/Endemism.pm
+++ b/lib/Biodiverse/Indices/Endemism.pm
@@ -761,7 +761,8 @@ sub _calc_endemism {
         ? $args{label_hash1}
         : $args{label_hash_all};
 
-    #  allows us to use this for any other basedata get_* function
+    #  Allows us to use this for any other basedata get_* function.
+    #  calc_rarity is an example of this.
     my $function   = $args{function} || 'get_range';
     my $range_hash = $args{label_range_hash} || {};
 

--- a/lib/Biodiverse/Indices/Indices.pm
+++ b/lib/Biodiverse/Indices/Indices.pm
@@ -61,7 +61,7 @@ sub get_metadata_calc_richness {
         name            => 'Richness',
         description     => 'Count the number of labels in the neighbour sets',
         type            => 'Lists and Counts',
-        pre_calc        => 'calc_abc',
+        pre_calc        => ['_calc_abc_any'],
         uses_nbr_lists  => 1,  #  how many sets of neighbour lists it must have
         distribution => 'nonnegative',
         indices         => {
@@ -192,7 +192,7 @@ sub get_metadata_is_dissimilarity_valid {
             }
         },
         type            => 'Taxonomic Dissimilarity and Comparison',
-        pre_calc        => 'calc_abc',
+        pre_calc        => ['_calc_abc_any'],
     );
 
     return $metadata_class->new(\%metadata);
@@ -283,7 +283,7 @@ sub get_metadata_calc_kulczynski2 {
             },
         },
         type            => 'Taxonomic Dissimilarity and Comparison',
-        pre_calc        => [qw /calc_abc is_dissimilarity_valid/],
+        pre_calc        => [qw /_calc_abc_any is_dissimilarity_valid/],
         uses_nbr_lists  => 2,
     );
 
@@ -329,7 +329,7 @@ sub get_metadata_calc_sorenson {
             }
         },
         type            => 'Taxonomic Dissimilarity and Comparison',
-        pre_calc        => [qw /calc_abc is_dissimilarity_valid/],
+        pre_calc        => [qw /_calc_abc_any is_dissimilarity_valid/],
         uses_nbr_lists  => 2,
     );
 
@@ -360,7 +360,7 @@ sub get_metadata_calc_jaccard {
         description     => 'Jaccard dissimilarity between the labels in neighbour sets 1 and 2.',
         type            => 'Taxonomic Dissimilarity and Comparison',
         uses_nbr_lists  => 2,  #  how many sets of lists it must have
-        pre_calc        => [qw /calc_abc is_dissimilarity_valid/],
+        pre_calc        => [qw /_calc_abc_any is_dissimilarity_valid/],
         formula         => [
             '= 1 - \frac{A}{A + B + C}',
             $self->get_formula_explanation_ABC,
@@ -457,7 +457,7 @@ sub get_metadata_calc_nestedness_resultant {
         uses_nbr_lists  => 2,  #  how many sets of lists it must have
         reference       => 'Baselga (2010) Glob Ecol Biogeog.  '
                            . 'https://doi.org/10.1111/j.1466-8238.2009.00490.x',
-        pre_calc        => [qw /calc_abc/],
+        pre_calc        => ['_calc_abc_any'],
         formula         => [
             '=\frac{ \left | B - C \right | }{ 2A + B + C } '
             . '\times \frac { A }{ A + min (B, C) }'
@@ -711,7 +711,7 @@ sub get_metadata_calc_beta_diversity {
         },
         type            => 'Taxonomic Dissimilarity and Comparison',
         uses_nbr_lists  => 2,  #  how many sets of lists it must have
-        pre_calc        => 'calc_abc',
+        pre_calc        => ['_calc_abc_any'],
     );
 
     return $metadata_class->new(\%metadata);
@@ -742,7 +742,7 @@ sub get_metadata_calc_s2 {
         name            => 'S2',
         type            => 'Taxonomic Dissimilarity and Comparison',
         description     => "S2 dissimilarity between two sets of labels\n",
-        pre_calc        => 'calc_abc',
+        pre_calc        => ['_calc_abc_any'],
         uses_nbr_lists  => 2,  #  how many sets of lists it must have
         reference   => 'Lennon et al. (2001) J Animal Ecol.  '
                         . 'https://doi.org/10.1046/j.0021-8790.2001.00563.x',
@@ -1396,7 +1396,7 @@ sub get_metadata_calc_abc_counts {
                 lumper      => 1,
             },
         },
-        pre_calc        => 'calc_abc',
+        pre_calc        => ['_calc_abc_any'],
         uses_nbr_lists  => 2,  #  how many sets of lists it must have
     );  #  add to if needed
 
@@ -1405,7 +1405,6 @@ sub get_metadata_calc_abc_counts {
 
 sub calc_abc_counts {
     my $self = shift;
-
     my %args = @_;  #  rest of args into a hash
 
     my %results = (
@@ -1415,10 +1414,7 @@ sub calc_abc_counts {
         ABC_ABC => $args{ABC},
     );
 
-    return wantarray
-            ? %results
-            : \%results;
-
+    return wantarray ? %results : \%results;
 }
 
 #  for some indices where a, b, c & d are needed
@@ -1449,7 +1445,7 @@ sub get_metadata_calc_d {
         description     => $description,
         type            => 'Lists and Counts',
         uses_nbr_lists  => 1,
-        pre_calc        => 'calc_abc',
+        pre_calc        => ['_calc_abc_any'],
         indices         => {
             ABC_D => {
                 description  => 'Count of labels not in either neighbour set (D score)',
@@ -1469,7 +1465,7 @@ sub get_metadata_calc_elements_used {
         name            => 'Element counts',
         description     => "Counts of elements used in neighbour sets 1 and 2.\n",
         type            => 'Lists and Counts',
-        pre_calc        => 'calc_abc',
+        pre_calc        => ['_calc_abc_any'],
         uses_nbr_lists  => 1,  #  how many sets of lists it must have
         distribution => 'nonnegative',
         indices         => {
@@ -1573,7 +1569,7 @@ sub get_metadata_calc_element_lists_used {
             . 'The return types are inconsistent. New code should use '
             . 'calc_element_lists_used_as_arrays',
         type            => 'Lists and Counts',
-        pre_calc        => 'calc_abc',
+        pre_calc        => ['_calc_abc_any'],
         uses_nbr_lists  => 1,  #  how many sets of lists it must have
         indices         => {
             EL_LIST_SET1  => {
@@ -1637,7 +1633,7 @@ sub get_metadata_calc_element_lists_used_as_arrays {
         description     => "Arrays of elements used in neighbour sets 1 and 2.\n"
             . 'These form the basis for all the spatial calculations.',
         type            => 'Lists and Counts',
-        pre_calc        => 'calc_abc',
+        pre_calc        => ['_calc_abc_any'],
         uses_nbr_lists  => 1,  #  how many sets of lists it must have
         indices         => {
             EL_ARRAY_SET1  => {
@@ -1707,15 +1703,20 @@ sub _calc_abc_any {
     my $self = shift;
 
     my $cache_hash = $self->get_cached_value('AS_RESULTS_FROM_LOCAL');
-    my $cached
-        = List::Util::first {$cache_hash->{$_}}
-          qw/calc_abc calc_abc2 calc_abc3/;
+    my $cache_key
+        = List::Util::first {defined $cache_hash->{$_}}
+          (qw/calc_abc calc_abc2 calc_abc3/);
 
-    #  fall back to calc_abc if nothing had an explicit dependency
-    $cached ||= $self->calc_abc(@_);
+    # say STDERR 'NO previous cache key'
+    #     if !$cache_key;
 
-    # croak 'No previous calc_abc results found'
-    #     if !$cached;
+    #  fall back to calc_abc if nothing had an explicit abc dependency
+    my $cached = $cache_key
+        ? $cache_hash->{$cache_key}
+        : $self->calc_abc(@_);
+
+    croak 'No previous calc_abc results found'
+        if !$cached;
 
     return wantarray ? %$cached : $cached;
 }

--- a/lib/Biodiverse/Indices/Indices.pm
+++ b/lib/Biodiverse/Indices/Indices.pm
@@ -1702,7 +1702,7 @@ sub get_metadata__calc_abc_any {
 sub _calc_abc_any {
     my $self = shift;
 
-    my $cache_hash = $self->get_cached_value('AS_RESULTS_FROM_LOCAL');
+    my $cache_hash = $self->get_param('AS_RESULTS_FROM_LOCAL');
     my $cache_key
         = List::Util::first {defined $cache_hash->{$_}}
           (qw/calc_abc calc_abc2 calc_abc3/);
@@ -1738,7 +1738,7 @@ sub get_metadata_calc_abc {
 sub calc_abc {  #  wrapper for _calc_abc - use the other wrappers for actual GUI stuff
     my ($self, %args) = @_;
 
-    my $cache_hash = $self->get_cached_value('AS_RESULTS_FROM_LOCAL');
+    my $cache_hash = $self->get_param('AS_RESULTS_FROM_LOCAL');
     my $cached
         = $cache_hash->{calc_abc2} || $cache_hash->{calc_abc3};
 

--- a/lib/Biodiverse/Indices/Indices.pm
+++ b/lib/Biodiverse/Indices/Indices.pm
@@ -1738,6 +1738,22 @@ sub get_metadata_calc_abc {
 sub calc_abc {  #  wrapper for _calc_abc - use the other wrappers for actual GUI stuff
     my ($self, %args) = @_;
 
+    my $cache_hash = $self->get_cached_value('AS_RESULTS_FROM_LOCAL');
+    my $cached
+        = $cache_hash->{calc_abc2} || $cache_hash->{calc_abc3};
+
+    if ($cached) {
+        #  create a shallow copy and then override the label hashes
+        my %results = %$cached;
+        foreach my $key (qw/label_hash1 label_hash2 label_hash_all/) {
+            my $href = $results{$key};
+            my %h;
+            @h{keys %$href} = (1) x scalar keys %{$href};
+            $results{$key} = \%h;
+        }
+        return wantarray ? %results : \%results;
+    }
+
     delete @args{qw/count_samples count_labels}/};
 
     return $self->_calc_abc_dispatcher(%args);

--- a/lib/Biodiverse/Indices/Indices.pm
+++ b/lib/Biodiverse/Indices/Indices.pm
@@ -1688,6 +1688,38 @@ sub calc_element_lists_used_as_arrays {
 }
 
 
+sub get_metadata__calc_abc_any {
+
+    my %metadata = (
+        name            => '_calc_abc_any',
+        description     => 'Special sub for when we only need the keys, '
+                         . 'not the values, so can use any of /calc_abc[23]?/',
+        type            => 'not_for_gui',
+        indices         => {},
+        uses_nbr_lists  => 1,  #  how many sets of lists it must have
+        required_args   => [$RE_ABC_REQUIRED_ARGS],  #experimental - https://github.com/shawnlaffan/biodiverse/issues/336
+    );
+
+    return $metadata_class->new(\%metadata);
+}
+
+sub _calc_abc_any {
+    my $self = shift;
+
+    my $cache_hash = $self->get_cached_value('AS_RESULTS_FROM_LOCAL');
+    my $cached
+        = List::Util::first {$cache_hash->{$_}}
+          qw/calc_abc calc_abc2 calc_abc3/;
+
+    #  fall back to calc_abc if nothing had an explicit dependency
+    $cached ||= $self->calc_abc(@_);
+
+    # croak 'No previous calc_abc results found'
+    #     if !$cached;
+
+    return wantarray ? %$cached : $cached;
+}
+
 sub get_metadata_calc_abc {
 
     my %metadata = (

--- a/lib/Biodiverse/Indices/LabelCounts.pm
+++ b/lib/Biodiverse/Indices/LabelCounts.pm
@@ -103,7 +103,7 @@ sub get_metadata_calc_label_count_quantile_position {
             },
         },
         type            => 'Lists and Counts',
-        pre_calc        => [qw /calc_element_lists_used calc_abc/],
+        pre_calc        => [qw /calc_element_lists_used _calc_abc_any/],
         required_args   => ['processing_element'],
         uses_nbr_lists  => 1,
     );  

--- a/lib/Biodiverse/Indices/LabelProperties.pm
+++ b/lib/Biodiverse/Indices/LabelProperties.pm
@@ -143,7 +143,7 @@ sub get_metadata_calc_lbprop_lists {
         description     => $desc,
         name            => 'Label property lists',
         type            => 'Element Properties',
-        pre_calc        => ['calc_abc'],
+        pre_calc        => ['_calc_abc_any'],
         uses_nbr_lists  => 1,
         indices         => \%indices,
     );

--- a/lib/Biodiverse/Indices/Matrix_Indices.pm
+++ b/lib/Biodiverse/Indices/Matrix_Indices.pm
@@ -32,7 +32,7 @@ sub get_metadata_calc_matrix_stats {
                             . 'Labels not in the matrix are ignored.',
         type            => 'Matrix',
         required_args   => {matrix_ref => 1}, #  must be set for it to be used
-        pre_calc        => 'calc_abc',
+        pre_calc        => ['calc_abc'],
         uses_nbr_lists  => 1,  #  how many sets of lists it must have
         indices         => {
             MX_MEAN      => {description => 'Mean'},
@@ -148,7 +148,7 @@ sub get_metadata_calc_compare_dissim_matrix_values {
                            . q{This calculation assumes a matrix of dissimilarities }
                            . q{and uses 0 as identical, so take care).},
         type            => 'Matrix',
-        pre_calc        => 'calc_abc',
+        pre_calc        => '_calc_abc_any',
         required_args   => ['matrix_ref'],
         uses_nbr_lists  => 2,  #  how many sets of lists it must have
         indices => {

--- a/lib/Biodiverse/Indices/Phylogenetic.pm
+++ b/lib/Biodiverse/Indices/Phylogenetic.pm
@@ -1603,7 +1603,7 @@ sub get_metadata_calc_labels_on_tree {
         },
         type            => 'Phylogenetic Indices',  #  keeps it clear of the other indices in the GUI
         pre_calc_global => [qw /get_labels_not_on_tree/],
-        pre_calc        => ['_calc_abc_any'],
+        pre_calc        => ['calc_abc'],
         uses_nbr_lists  => 1,  #  how many lists it must have
         required_args   => ['tree_ref'],
     );

--- a/lib/Biodiverse/Indices/Phylogenetic.pm
+++ b/lib/Biodiverse/Indices/Phylogenetic.pm
@@ -2679,6 +2679,15 @@ sub _calc_phylo_abc_lists {
         el_list  => $args{element_list1},
     );
 
+    if (!@{$args{element_list2}}) {
+        my $res = {
+            PHYLO_A_LIST => {},
+            PHYLO_B_LIST => $nodes_in_path1,
+            PHYLO_C_LIST => {},
+        };
+        return wantarray ? %$res : $res;
+    }
+
     my $nodes_in_path2 = @{$args{element_list2}}
         ? $self->get_path_lengths_to_root_node (
             %args,

--- a/lib/Biodiverse/Indices/Phylogenetic.pm
+++ b/lib/Biodiverse/Indices/Phylogenetic.pm
@@ -2918,22 +2918,18 @@ sub _calc_phylo_aed_t {
     my $self = shift;
     my %args = @_;
 
-    my $aed_hash   = $args{PHYLO_AED_LIST};
-    my $label_hash = $args{label_hash_all};
+    \my %aed_hash   = $args{PHYLO_AED_LIST};
+    \my %label_hash = $args{label_hash_all};
     my $aed_t;
     my %scores;
 
   LABEL:
-    foreach my $label (keys %$label_hash) {
-        my $abundance = $label_hash->{$label};
+    foreach my $label (keys %label_hash) {
+        next LABEL if !exists $aed_hash{$label};
 
-        next LABEL if !exists $aed_hash->{$label};
-
-        my $aed_score = $aed_hash->{$label};
-        my $weight    = $abundance * $aed_score;
-
+        my $weight      = $label_hash{$label} * $aed_hash{$label};
         $scores{$label} = $weight;
-        $aed_t += $weight;
+        $aed_t         += $weight;
     }
 
     my %results = (
@@ -2986,20 +2982,20 @@ sub calc_phylo_aed {
     my $self = shift;
     my %args = @_;
 
-    my $label_hash = $args{label_hash_all};
-    my $es_wts     = $args{ES_SCORES};
-    my $ed_wts     = $args{ED_SCORES};
-    my $aed_wts    = $args{AED_SCORES};
+    \my %label_hash = $args{label_hash_all};
+    \my %es_wts     = $args{ES_SCORES};
+    \my %ed_wts     = $args{ED_SCORES};
+    \my %aed_wts    = $args{AED_SCORES};
 
     my (%es, %ed, %aed);
     # now loop over the terminals and extract the weights (would slices be faster?)
     # Do we want the proportional values?  Divide by PD to get them.
   LABEL:
-    foreach my $label (keys %$label_hash) {
-        next LABEL if !exists $aed_wts->{$label};
-        $aed{$label} = $aed_wts->{$label};
-        $ed{$label}  = $ed_wts->{$label};
-        $es{$label}  = $es_wts->{$label};
+    foreach my $label (keys %label_hash) {
+        next LABEL if !exists $aed_wts{$label};
+        $aed{$label} = $aed_wts{$label};
+        $ed{$label}  = $ed_wts{$label};
+        $es{$label}  = $es_wts{$label};
     }
 
     my %results = (
@@ -3055,7 +3051,7 @@ sub get_aed_scores {
         my $node_ref = eval {
             $tree->get_node_ref (node => $label);
         };
-        if (my $e = $EVAL_ERROR) {  #  still needed? 
+        if (my $e = $EVAL_ERROR) {  #  still needed?
             next LABEL if Biodiverse::Tree::NotExistsNode->caught;
             croak $e;
         }

--- a/lib/Biodiverse/Indices/Phylogenetic.pm
+++ b/lib/Biodiverse/Indices/Phylogenetic.pm
@@ -204,7 +204,7 @@ sub get_metadata_calc_last_shared_ancestor_props {
         type            => 'Phylogenetic Indices',
         required_args   => ['tree_ref'],
         pre_calc        => [
-            'calc_abc', 'get_sub_tree_as_hash',
+            '_calc_abc_any', 'get_sub_tree_as_hash',
             'get_last_shared_ancestor_from_subtree',
         ],
         uses_nbr_lists  => 1,  #  how many lists it must have
@@ -1603,7 +1603,7 @@ sub get_metadata_calc_labels_on_tree {
         },
         type            => 'Phylogenetic Indices',  #  keeps it clear of the other indices in the GUI
         pre_calc_global => [qw /get_labels_not_on_tree/],
-        pre_calc        => ['calc_abc'],
+        pre_calc        => ['_calc_abc_any'],
         uses_nbr_lists  => 1,  #  how many lists it must have
         required_args   => ['tree_ref'],
     );
@@ -1646,7 +1646,7 @@ sub get_metadata_calc_labels_not_on_tree {
         },
         type            => 'Phylogenetic Indices',  #  keeps it clear of the other indices in the GUI
         pre_calc_global => [qw /get_labels_not_on_tree/],
-        pre_calc        => ['calc_abc'],
+        pre_calc        => ['_calc_abc_any'],
         uses_nbr_lists  => 1,  #  how many lists it must have
         required_args   => ['tree_ref'],
     );
@@ -2533,7 +2533,7 @@ sub get_metadata_calc_phylo_abc {
         description     =>  'Calculate the shared and not shared branch lengths between two sets of labels',
         type            =>  'Phylogenetic Turnover',
         # pre_calc        =>  [qw /_calc_phylo_abc_lists calc_abc/],
-        pre_calc        =>  [qw /calc_abc/],
+        pre_calc        =>  ['_calc_abc_any'],
         pre_calc_global =>  [qw /get_trimmed_tree get_path_length_cache set_path_length_cache_by_group_flag/],
         uses_nbr_lists  =>  2,  #  how many sets of lists it must have
         distribution    => 'nonnegative',  # default
@@ -2945,7 +2945,7 @@ sub get_metadata_calc_phylo_aed {
         name            =>  'Evolutionary distinctiveness',
         description     =>  $descr,
         type            =>  'Phylogenetic Indices',
-        pre_calc        => [qw /calc_abc/],
+        pre_calc        => ['_calc_abc_any'],
         pre_calc_global => [qw /get_aed_scores/],
         uses_nbr_lists  =>  1,
         reference       => 'Cadotte & Davies (2010) https://doi.org/10.1111/j.1472-4642.2010.00650.x',

--- a/lib/Biodiverse/Indices/PhylogeneticRelative.pm
+++ b/lib/Biodiverse/Indices/PhylogeneticRelative.pm
@@ -266,20 +266,30 @@ sub calc_phylo_rpe_central {
     my $self = shift;
     my %args = @_;
 
-    my %results = $self->calc_phylo_rpe2 (
-        %args,
-        PE_WE_P => $args{PEC_WE_P},
-        PE_WE   => $args{PEC_WE},
-        PE_RANGELIST       => $args{PEC_RANGELIST},
-        PE_LOCAL_RANGELIST => $args{PEC_LOCAL_RANGELIST},
-    );
+    my $results;
+
+    if (!@{$args{element_list2} // []}) {
+        #  We just copy the calc_phylo_rpe2 results
+        #  if there are no nbrs in set2
+        my $cache_hash = $self->get_param('AS_RESULTS_FROM_LOCAL');
+        $results = $cache_hash->{calc_phylo_rpe2};
+    }
+
+    if (!$results) {
+        $results = $self->calc_phylo_rpe2(
+            %args,
+            PE_WE_P            => $args{PEC_WE_P},
+            PE_WE              => $args{PEC_WE},
+            PE_RANGELIST       => $args{PEC_RANGELIST},
+            PE_LOCAL_RANGELIST => $args{PEC_LOCAL_RANGELIST},
+        );
+    }
 
     my %results2;
-    foreach my $key (keys %results) {
-        my $new_key = $key;
+    foreach my $key (keys %$results) {
         #  will need to be changed if we rename the RPE indices
-        $new_key =~ s/2$/C/;
-        $results2{$new_key} = $results{$key};
+        my $new_key = ($key =~ s/2$/C/r);
+        $results2{$new_key} = $results->{$key};
     }
 
     return wantarray ? %results2 : \%results2;

--- a/lib/Biodiverse/Indices/PhylogeneticRelative.pm
+++ b/lib/Biodiverse/Indices/PhylogeneticRelative.pm
@@ -336,6 +336,22 @@ sub calc_phylo_rpe2 {
     my $self = shift;
     my %args = @_;
 
+    if (!@{$args{element_list2} // []}) {
+        #  We just copy the calc_phylo_rpe_central results
+        #  if there are no nbrs in set2
+        my $cache_hash = $self->get_param('AS_RESULTS_FROM_LOCAL');
+        if (my $cached = $cache_hash->{calc_phylo_rpe_central}) {
+            my %results;
+            foreach my $key (keys %$cached) {
+                #  will need to be changed if we rename the RPE indices
+                my $new_key = ($key =~ s/C$/2/r);
+                $results{$new_key} = $cached->{$key};
+            }
+            return wantarray ? %results : \%results;
+        }
+    }
+
+
     my $orig_tree_ref = $args{trimmed_tree};
     my $orig_total_tree_length = $orig_tree_ref->get_total_tree_length;
 

--- a/lib/Biodiverse/Indices/PhylogeneticRelative.pm
+++ b/lib/Biodiverse/Indices/PhylogeneticRelative.pm
@@ -453,7 +453,7 @@ sub get_metadata_calc_labels_not_on_trimmed_tree {
         },
         type            => 'Phylogenetic Indices (relative)',  #  keeps it clear of the other indices in the GUI
         pre_calc_global => [qw /get_labels_not_on_trimmed_tree/],
-        pre_calc        => ['calc_abc'],
+        pre_calc        => ['_calc_abc_any'],
         uses_nbr_lists  => 1,  #  how many lists it must have
     );
 
@@ -494,7 +494,7 @@ sub get_metadata_get_labels_not_on_trimmed_tree {
 
     my %metadata = (
         name            => 'get_labels_not_on_trimmed_tree',
-        description     => 'List of lables not on the trimmed tree',
+        description     => 'List of labels not on the trimmed tree',
         pre_calc_global => [qw /get_trimmed_tree/],
         indices => {
             labels_not_on_trimmed_tree => {

--- a/lib/Biodiverse/Indices/Rarity.pm
+++ b/lib/Biodiverse/Indices/Rarity.pm
@@ -165,6 +165,20 @@ sub _calc_rarity_central {
     my $self = shift;
     my %args = @_;
 
+    #  If we have no nbrs in set 2 then we are the same as the "whole" variant.
+    #  So just grab its values if it has already been calculated.
+    if (!keys %{$args{label_hash2}}) {
+        my $cache_hash = $self->get_param('AS_RESULTS_FROM_LOCAL');
+        if (my $cached = $cache_hash->{_calc_rarity_whole}) {
+            my %remapped;
+            foreach my $key (keys %$cached) {
+                my $key2 = ($key =~ s/^RAREW/RAREC/r);
+                $remapped{$key2} = $cached->{$key};
+            }
+            return wantarray ? %remapped : \%remapped;
+        }
+    }
+
     my %hash = $self->_calc_endemism (
         %args,
         end_central => 1,
@@ -294,6 +308,21 @@ sub calc_rarity_whole_lists {
 sub _calc_rarity_whole {
     my $self = shift;
     my %args = @_;
+
+    #  If we have no nbrs in set 2 then we are the same as the "whole" variant.
+    #  So just grab its values if it has already been calculated.
+    if (!keys %{$args{label_hash2}}) {
+        my $cache_hash = $self->get_param('AS_RESULTS_FROM_LOCAL');
+        if (my $cached = $cache_hash->{_calc_rarity_central}) {
+            my %remapped;
+            foreach my $key (keys %$cached) {
+                my $key2 = ($key =~ s/^RAREC/RAREW/r);
+                $remapped{$key2} = $cached->{$key};
+            }
+            return wantarray ? %remapped : \%remapped;
+        }
+    }
+
 
     my %hash = $self->_calc_endemism (
         %args,

--- a/lib/Biodiverse/Indices/Rarity.pm
+++ b/lib/Biodiverse/Indices/Rarity.pm
@@ -173,9 +173,8 @@ sub _calc_rarity_central {
     );
 
     my %hash2;
-    while (my ($key, $value) = each %hash) {
-        my $key2 = $key;
-        $key2 =~ s/^END/RAREC/;
+    foreach my $key (keys %hash) {
+        my $key2 = ($key =~ s/^END/RAREC/r);
         $hash2{$key2} = $hash{$key};
     }
 
@@ -304,9 +303,8 @@ sub _calc_rarity_whole {
     );
 
     my %hash2;
-    while (my ($key, $value) = each %hash) {
-        my $key2 = $key;
-        $key2 =~ s/^END/RAREW/;
+    foreach my $key (keys %hash) {
+        my $key2 = ($key =~ s/^END/RAREW/r);
         $hash2{$key2} = $hash{$key};
     }
 

--- a/lib/Biodiverse/Indices/Rarity.pm
+++ b/lib/Biodiverse/Indices/Rarity.pm
@@ -5,8 +5,10 @@ use 5.020;
 
 our $VERSION = '4.99_002';
 
-#  we need access to one sub from Endemism.pm
-use parent qw /Biodiverse::Indices::Endemism/;
+#  we need access to one sub from Endemism.pm,
+#  but since we are loaded by Indices.pm
+#  there is no need to inherit from it here.
+# use parent qw /Biodiverse::Indices::Endemism/;
 
 my $metadata_class = 'Biodiverse::Metadata::Indices';
 
@@ -114,7 +116,7 @@ sub get_metadata_calc_rarity_central_lists {
         description     => 'Lists used in rarity central calculations',
         name            => 'Rarity central lists',
         type            => 'Rarity',
-        pre_calc        => qw /_calc_rarity_central/,
+        pre_calc        => ['_calc_rarity_central'],
         uses_nbr_lists  => 1,  #  how many sets of lists it must have
         indices => {
             RAREC_WTLIST      => {
@@ -256,7 +258,7 @@ sub get_metadata_calc_rarity_whole_lists {
         description     => 'Lists used in rarity whole calculations',
         name            => 'Rarity whole lists',
         type            => 'Rarity',
-        pre_calc        => qw /_calc_rarity_whole/,
+        pre_calc        => '_calc_rarity_whole',
         uses_nbr_lists  => 1,  #  how many sets of lists it must have
         indices => {
             RAREW_WTLIST      => {

--- a/lib/Biodiverse/Metadata/Indices.pm
+++ b/lib/Biodiverse/Metadata/Indices.pm
@@ -4,6 +4,7 @@ use warnings;
 use 5.016;
 use Carp;
 use Readonly;
+use Ref::Util qw /is_hashref/;
 
 use parent qw /Biodiverse::Metadata/;
 
@@ -29,6 +30,9 @@ sub new {
     bless $self, $class;
 
     my $indices = $self->{indices} // {};
+    croak "Indices not a hash ref for $self->{name}"
+     if !is_hashref $indices;
+
     foreach my $index (keys %{$indices}) {
         #  triggers it being set
         $self->get_index_bounds ($index);


### PR DESCRIPTION
This PR includes several optimisations.  Chief among them are:

  * Implement _calc_abc_any for cases where a depending method only needs the label hash keys or element lists
  * calc_abc grabs and modifies results from calc_abc2 or calc_abc3 if already run, thus saving some processing
  * calc_abc2 or calc_abc3 are always run before calc_abc
  * add a hierarchical _calc_abc variant for cases such as cluster node calcs where the label hashes can be generated from the child node results instead of processing the full list of terminals
  * some other general index optimisations such as result sharing when nbr set 2 is empty