### PR TITLE
GUI randomisations: hide/show box-group labels

### DIFF
--- a/lib/Biodiverse/GUI/ParametersTable.pm
+++ b/lib/Biodiverse/GUI/ParametersTable.pm
@@ -144,6 +144,7 @@ sub fill {
                     $table->attach($l,  0, 1, $rows, $rows + 1, 'fill', [], 0, 0);
                     $table->attach($hbox, 1, 2, $rows, $rows + 1, $fill_flags, [], 0, 0);
                     $l->show;
+                    $self->{box_group_labels}{$box_group_name} = $l;
                 }
             }
             $hbox //= $self->{box_groups}{$box_group_name};

--- a/lib/Biodiverse/GUI/Tabs/Randomise.pm
+++ b/lib/Biodiverse/GUI/Tabs/Randomise.pm
@@ -385,8 +385,31 @@ sub on_function_changed {
         }
     }
 
+    $self->show_hide_box_group_labels;
+
     return;
 }
+
+sub show_hide_box_group_labels {
+    my $self = shift;
+    my $params_table = $self->get_parameters_table;
+    my $boxes = $params_table->{box_groups};
+    foreach my ($name, $box) (%$boxes) {
+        # say STDERR "$name, $box";
+        my $visible = 0;
+        $box->foreach (
+            sub {
+                $visible ||= $_[0]->get_visible;
+            }
+        );
+        # say "$name is visible: $visible";
+        my $label = $params_table->{box_group_labels}{$name};
+        if ($label) {
+            $label->set_visible($visible);
+        }
+    }
+}
+
 
 sub get_parameters_table {
     my $self = shift;

--- a/lib/Biodiverse/Randomise/CurveBall.pm
+++ b/lib/Biodiverse/Randomise/CurveBall.pm
@@ -130,9 +130,7 @@ END_PROGRESS_TEXT
 
     #  Basic algorithm:
     #  pick two different groups at random
-    #  pick two different labels at random
-    #  if label1 is already in group2, or label2 in group1, then try again
-    #  else swap the labels between groups
+    #  swap as many labels as possible
 
     if (!looks_like_number $target_swap_count || $target_swap_count <= 0) {
         $target_swap_count = 2 * $non_zero_mx_cells;


### PR DESCRIPTION
This hides or shows the box group labels as a function of the visibility of the constituent widgets.

If none are visible then the label is hidden.

This will improve the user experience as non-relevant labels are no longer shown.