### PR TITLE
GUI: Simplify the naming scheme for the pan/zoom widgets

### DIFF
--- a/bin/ui/hboxClusteringPage.ui
+++ b/bin/ui/hboxClusteringPage.ui
@@ -34,7 +34,7 @@
             <property name="has-tooltip">True</property>
             <property name="tooltip-text" translatable="yes">Select (S or B)</property>
             <child>
-              <object class="GtkToggleButton" id="btnSelectToolCL">
+              <object class="GtkToggleButton" id="btnSelectTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -62,7 +62,7 @@
             <property name="has-tooltip">True</property>
             <property name="tooltip-text" translatable="yes">Pan (C)</property>
             <child>
-              <object class="GtkToggleButton" id="btnPanToolCL">
+              <object class="GtkToggleButton" id="btnPanTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -89,7 +89,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Zoom In (Z)</property>
             <child>
-              <object class="GtkToggleButton" id="btnZoomInToolCL">
+              <object class="GtkToggleButton" id="btnZoomInTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -116,7 +116,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Zoom Out (X)</property>
             <child>
-              <object class="GtkToggleButton" id="btnZoomOutToolCL">
+              <object class="GtkToggleButton" id="btnZoomOutTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -143,7 +143,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Zoom to Fit (V)</property>
             <child>
-              <object class="GtkToggleButton" id="btnZoomFitToolCL">
+              <object class="GtkToggleButton" id="btnZoomFitTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>

--- a/bin/ui/hboxLabelsPage.ui
+++ b/bin/ui/hboxLabelsPage.ui
@@ -24,7 +24,7 @@
             <property name="has-tooltip">True</property>
             <property name="tooltip-text" translatable="yes">Select (S or B)</property>
             <child>
-              <object class="GtkToggleButton" id="btnSelectToolVL">
+              <object class="GtkToggleButton" id="btnSelectTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -52,7 +52,7 @@
             <property name="has-tooltip">True</property>
             <property name="tooltip-text" translatable="yes">Pan (C)</property>
             <child>
-              <object class="GtkToggleButton" id="btnPanToolVL">
+              <object class="GtkToggleButton" id="btnPanTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -79,7 +79,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Zoom In (Z)</property>
             <child>
-              <object class="GtkToggleButton" id="btnZoomInToolVL">
+              <object class="GtkToggleButton" id="btnZoomInTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -106,7 +106,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Zoom Out (X)</property>
             <child>
-              <object class="GtkToggleButton" id="btnZoomOutToolVL">
+              <object class="GtkToggleButton" id="btnZoomOutTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -133,7 +133,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Zoom to Fit (V)</property>
             <child>
-              <object class="GtkToggleButton" id="btnZoomFitToolVL">
+              <object class="GtkToggleButton" id="btnZoomFitTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>

--- a/bin/ui/hboxSpatialPage.ui
+++ b/bin/ui/hboxSpatialPage.ui
@@ -28,7 +28,7 @@
             <property name="has-tooltip">True</property>
             <property name="tooltip-text" translatable="yes">Select (S or B)</property>
             <child>
-              <object class="GtkToggleButton" id="btnSelectToolSP">
+              <object class="GtkToggleButton" id="btnSelectTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -56,7 +56,7 @@
             <property name="has-tooltip">True</property>
             <property name="tooltip-text" translatable="yes">Pan (C)</property>
             <child>
-              <object class="GtkToggleButton" id="btnPanToolSP">
+              <object class="GtkToggleButton" id="btnPanTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -83,7 +83,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Zoom In (Z)</property>
             <child>
-              <object class="GtkToggleButton" id="btnZoomInToolSP">
+              <object class="GtkToggleButton" id="btnZoomInTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -110,7 +110,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Zoom Out (X)</property>
             <child>
-              <object class="GtkToggleButton" id="btnZoomOutToolSP">
+              <object class="GtkToggleButton" id="btnZoomOutTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -137,7 +137,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Zoom to Fit (V)</property>
             <child>
-              <object class="GtkToggleButton" id="btnZoomFitToolSP">
+              <object class="GtkToggleButton" id="btnZoomFitTool">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>

--- a/lib/Biodiverse/GUI/Tabs/Clustering.pm
+++ b/lib/Biodiverse/GUI/Tabs/Clustering.pm
@@ -271,11 +271,11 @@ sub new {
         menuitem_cluster_overlays => {activate => \&on_overlays},
         spinClusters        => {'value-changed' => \&on_clusters_changed},
 
-        btnSelectToolCL     => {clicked => \&on_select_tool},
-        btnPanToolCL        => {clicked => \&on_pan_tool},
-        btnZoomInToolCL     => {clicked => \&on_zoom_in_tool},
-        btnZoomOutToolCL    => {clicked => \&on_zoom_out_tool},
-        btnZoomFitToolCL    => {clicked => \&on_zoom_fit_tool},
+        btnSelectTool       => {clicked => \&on_select_tool},
+        btnPanTool          => {clicked => \&on_pan_tool},
+        btnZoomInTool       => {clicked => \&on_zoom_in_tool},
+        btnZoomOutTool      => {clicked => \&on_zoom_out_tool},
+        btnZoomFitTool      => {clicked => \&on_zoom_fit_tool},
 
         menuitem_cluster_colour_mode_hue  => {toggled  => \&on_colour_mode_changed},
         menuitem_cluster_colour_mode_sat  => {activate => \&on_colour_mode_changed},

--- a/lib/Biodiverse/GUI/Tabs/Labels.pm
+++ b/lib/Biodiverse/GUI/Tabs/Labels.pm
@@ -185,15 +185,15 @@ sub new {
         );
     };
 
-    $sig_clicked->('btnSelectToolVL',  \&on_select_tool);
-    $sig_clicked->('btnPanToolVL',     \&on_pan_tool);
-    $sig_clicked->('btnZoomInToolVL',  \&on_zoom_in_tool);
-    $sig_clicked->('btnZoomOutToolVL', \&on_zoom_out_tool);
-    $sig_clicked->('btnZoomFitToolVL', \&on_zoom_fit_tool);
+    $sig_clicked->('btnSelectTool',  \&on_select_tool);
+    $sig_clicked->('btnPanTool',     \&on_pan_tool);
+    $sig_clicked->('btnZoomInTool',  \&on_zoom_in_tool);
+    $sig_clicked->('btnZoomOutTool', \&on_zoom_out_tool);
+    $sig_clicked->('btnZoomFitTool', \&on_zoom_fit_tool);
 
     $self->get_xmlpage_object('menuitem_labels_overlays')->signal_connect_swapped(activate => \&on_overlays, $self);
 
-    $self->get_xmlpage_object('btnSelectToolVL')->set_active(1);
+    $self->get_xmlpage_object('btnSelectTool')->set_active(1);
 
     $self->get_xmlpage_object('menuitem_labels_show_legend')->signal_connect_swapped(
         toggled => \&on_show_hide_legend,

--- a/lib/Biodiverse/GUI/Tabs/Spatial.pm
+++ b/lib/Biodiverse/GUI/Tabs/Spatial.pm
@@ -267,11 +267,11 @@ sub new {
         comboLists      => {changed => \&on_active_list_changed},
         comboIndices    => {changed => \&on_active_index_changed},
 
-        btnSelectToolSP  => {clicked => \&on_select_tool},
-        btnPanToolSP     => {clicked => \&on_pan_tool},
-        btnZoomInToolSP  => {clicked => \&on_zoom_in_tool},
-        btnZoomOutToolSP => {clicked => \&on_zoom_out_tool},
-        btnZoomFitToolSP => {clicked => \&on_zoom_fit_tool},
+        btnSelectTool    => {clicked => \&on_select_tool},
+        btnPanTool       => {clicked => \&on_pan_tool},
+        btnZoomInTool    => {clicked => \&on_zoom_in_tool},
+        btnZoomOutTool   => {clicked => \&on_zoom_out_tool},
+        btnZoomFitTool   => {clicked => \&on_zoom_fit_tool},
 
         menuitem_spatial_overlays => {activate => \&on_overlays},
         menuitem_spatial_colour_mode_hue  => {toggled  => \&on_colour_mode_changed},

--- a/lib/Biodiverse/GUI/Tabs/SpatialMatrix.pm
+++ b/lib/Biodiverse/GUI/Tabs/SpatialMatrix.pm
@@ -135,11 +135,11 @@ sub new {
         comboIndices   => { changed   => \&on_active_index_changed },
 
         #  need to refactor common elements with Spatial.pm
-        btnSelectToolSP  => {clicked => \&on_select_tool},
-        btnPanToolSP     => {clicked => \&on_pan_tool},
-        btnZoomInToolSP  => {clicked => \&on_zoom_in_tool},
-        btnZoomOutToolSP => {clicked => \&on_zoom_out_tool},
-        btnZoomFitToolSP => {clicked => \&on_zoom_fit_tool},
+        btnSelectTool    => {clicked => \&on_select_tool},
+        btnPanTool       => {clicked => \&on_pan_tool},
+        btnZoomInTool    => {clicked => \&on_zoom_in_tool},
+        btnZoomOutTool   => {clicked => \&on_zoom_out_tool},
+        btnZoomFitTool   => {clicked => \&on_zoom_fit_tool},
 
         menuitem_spatial_overlays => {activate => \&on_overlays},
 

--- a/lib/Biodiverse/GUI/Tabs/Tab.pm
+++ b/lib/Biodiverse/GUI/Tabs/Tab.pm
@@ -454,20 +454,10 @@ sub choose_tool {
     $self->{previous_tool} = $old_tool;
 
     if ($old_tool) {
-        #  should really edit the ui files so they use the same names
-        state %widget_suffixes = (
-            'Biodiverse::GUI::Tabs::Labels'        => 'VL',
-            'Biodiverse::GUI::Tabs::Clustering'    => 'CL',
-            'Biodiverse::GUI::Tabs::Spatial'       => 'SP',
-            'Biodiverse::GUI::Tabs::SpatialMatrix' => 'SP',
-        );
-        my $class = blessed $self;
-        my $suffix = $widget_suffixes{$class} // die "Unknown tab class $class";
-
         $self->{ignore_tool_click} = 1;
-        my $widget = $self->get_xmlpage_object("btn${old_tool}Tool${suffix}");
+        my $widget = $self->get_xmlpage_object("btn${old_tool}Tool");
         $widget->set_active(0);
-        my $new_widget = $self->get_xmlpage_object("btn${tool}Tool${suffix}");
+        my $new_widget = $self->get_xmlpage_object("btn${tool}Tool");
         $new_widget->set_active(1);
         $self->{ignore_tool_click} = 0;
     }


### PR DESCRIPTION
The old naming scheme dates back to the monolithic glade file.

Each tab is in its own file now so the names can be the same across files and the handling code simplified.