### PR TITLE
Tree::trim_to_last_common_ancestor: ensure we reset the depth values

### DIFF
--- a/lib/Biodiverse/Indices.pm
+++ b/lib/Biodiverse/Indices.pm
@@ -1560,7 +1560,7 @@ sub run_dependencies {
 
     foreach my $calc (@$calc_list) {
         my $calc_results;
-
+say ":: $calc";
         #  if already cached then just grab it - should never happen now?
         if ( exists $as_results_from{$calc} ) {
             $calc_results = $as_results_from{$calc};

--- a/lib/Biodiverse/Indices/Phylogenetic.pm
+++ b/lib/Biodiverse/Indices/Phylogenetic.pm
@@ -1075,7 +1075,9 @@ sub _calc_pd_pe_clade_contributions {
 
   DEPTH:
     foreach my $name_arr (reverse @names_by_depth) {
-
+        #  the depths might not have been updated when the
+        #  tree was trimmed to the LCA
+        last DEPTH if !defined $name_arr;
       NODE_NAME:
         foreach my $node_name (@$name_arr) {
 
@@ -1097,7 +1099,7 @@ sub _calc_pd_pe_clade_contributions {
             $clade_score{$node_name} = $wt_sum;
         }
     }
-
+say 'x';
     my %results = (
         "${res_pfx}CLADE_SCORE"   => \%clade_score,
         "${res_pfx}CLADE_CONTR"   => \%contr,

--- a/lib/Biodiverse/Tree.pm
+++ b/lib/Biodiverse/Tree.pm
@@ -2810,6 +2810,7 @@ sub trim_to_last_common_ancestor {
     #  reset the tree node 
     $self->{TREE} = $root;
     $self->delete_all_cached_values;
+    $self->unset_all_depths;
     
     my $check = $self->get_root_node;
 
@@ -2817,6 +2818,14 @@ sub trim_to_last_common_ancestor {
     return;
 }
 
+#  they get recalculated on demand
+sub unset_all_depths {
+    my $self = shift;
+    foreach my $ref ($self->get_node_refs) {
+        $ref->set_depth_aa(undef);
+    }
+    return;
+}
 
 #  merge any single-child nodes with their children
 sub merge_knuckle_nodes {

--- a/t/13-Tree.t
+++ b/t/13-Tree.t
@@ -420,6 +420,10 @@ sub test_trim_tree_to_lca {
             }
         }
     }
+
+    my $orig_root = $tree->get_root_node;
+    is ($orig_root->get_depth, 0, 'orig root depth is zero');
+
     #  add some dangling parents
     my $root = $tree->get_root_node;
     for my $uppers (qw /a b c/) {
@@ -428,11 +432,25 @@ sub test_trim_tree_to_lca {
         $root = $node;
     }
 
+    #  clear the depths
+    foreach my $node ($tree->get_node_refs) {
+        $node->set_depth_aa(undef);
+    }
+    #  recalculate depths - these will include the dangling parents
+    foreach my $node ($tree->get_node_refs) {
+        my $d = $node->get_depth;
+        say $d;
+    }
+
+    is ($orig_root->get_depth, 3, 'orig root depth has changed');
+
     #  nasty test as it knows too much
     is ($tree->get_tree_ref->get_name, 'c', 'initial root node has correct name');
 
     $tree->trim_to_last_common_ancestor;
-    
+
+    is ($orig_root->get_depth, 0, 'orig root depth is back to zero');
+
     foreach my $should_not_exist (qw /a b c/) {
         ok (
             !$tree->exists_node (name => $should_not_exist),


### PR DESCRIPTION
This was causing issues with _calc_pd_pe_clade_contributions.

That has also been updated to handle trees trimmed before this fix.