### PR TITLE
Add support for volatile cache objects

### DIFF
--- a/lib/Biodiverse/Common.pm
+++ b/lib/Biodiverse/Common.pm
@@ -67,7 +67,8 @@ sub clone {
         #  https://rt.cpan.org/Public/Bug/Display.html?id=97525
         #  could use Sereal::Dclone for brevity
         my $encoder = Sereal::Encoder->new({
-            undef_unknown => 1,  #  strip any code refs
+            undef_unknown    => 1, #  strip any code refs
+            freeze_callbacks => 1,
         });
         my $decoder = Sereal::Decoder->new();
         eval {
@@ -741,8 +742,9 @@ sub save_to_sereal {
     use Sereal::Encoder ();
 
     my $encoder = Sereal::Encoder->new({
-        undef_unknown    => 1,  #  strip any code refs
-        protocol_version => 3,  #  keep compatibility with older files - should be an argument
+        undef_unknown    => 1, #  strip any code refs
+        protocol_version => 3, #  keep compatibility with older files - should be an argument
+        freeze_callbacks => 1,
     });
 
     open (my $fh, '>', $file) or die "Cannot open $file";

--- a/lib/Biodiverse/Common/Caching.pm
+++ b/lib/Biodiverse/Common/Caching.pm
@@ -1,7 +1,7 @@
 package Biodiverse::Common::Caching;
 use strict;
 use warnings;
-
+use 5.036;
 
 our $VERSION = '5.0';
 
@@ -78,5 +78,16 @@ sub delete_cached_value {
     delete $self->{_cache}{$key};
 }
 
+
+sub get_volatile_cache {
+    my $self = shift;
+    use Biodiverse::VCache;
+    $self->{_vcache} //= Biodiverse::VCache->new;
+}
+
+sub clear_volatile_cache {
+    my $self = shift;
+    delete $self->{_vcache};
+}
 
 1;

--- a/lib/Biodiverse/VCache.pm
+++ b/lib/Biodiverse/VCache.pm
@@ -1,0 +1,30 @@
+package Biodiverse::VCache;
+use strict;
+use warnings;
+use 5.036;
+
+our $VERSION = '5.0';
+
+#  A cache object for volatile things like Geo::GDAL::FFI objects that do not survive serialisation
+#  All it does is ensure the serialised object has no cache.
+#  Since it is volatile a new instance is returned on freeze and thaw.
+
+use parent 'Biodiverse::Common::Caching';
+
+sub new {
+    my $class = shift;
+    bless {}, ref ($class) || $class;
+}
+
+sub FREEZE {
+    my $self = shift;
+    return {};
+}
+
+sub THAW {
+    my ($class, $model) = @_;
+    $class->new;
+}
+
+1;
+


### PR DESCRIPTION
These are bare-bones objects that only do caching.

The important aspect is that they do not serialise their contents.

This ensures volatile variables such as file handles or Geo::GDAL::FFI objects are not serialised (providing, of course, that they are stored in the vcache).