### PR TITLE
Speed up the sp_sidedness conditions

### DIFF
--- a/lib/Biodiverse/BaseData.pm
+++ b/lib/Biodiverse/BaseData.pm
@@ -51,6 +51,7 @@ use parent qw {
     Biodiverse::BaseData::ManageOutputs
     Biodiverse::BaseData::Exclusions
     Biodiverse::BaseData::LabelRanges
+    Biodiverse::BaseData::FeatureData
 };
 
 our $EMPTY_STRING = q{};

--- a/lib/Biodiverse/BaseData.pm
+++ b/lib/Biodiverse/BaseData.pm
@@ -451,6 +451,12 @@ sub _describe {
 sub get_coord_bounds {
     my $self = shift;
 
+    state $cache_key = 'get_coord_bounds';
+    my $cached = $self->get_cached_value ($cache_key);
+
+    return wantarray ? %$cached : $cached
+        if $cached;
+
     #  do we use numeric or string comparison?
     my @numeric_comp;
     my @string_comp;
@@ -524,6 +530,8 @@ sub get_coord_bounds {
         MIN => \@min,
         MAX => \@max,
     );
+
+    $self->set_cached_value ($cache_key => \%bounds);
 
     return wantarray ? %bounds : \%bounds;
 }

--- a/lib/Biodiverse/BaseData.pm
+++ b/lib/Biodiverse/BaseData.pm
@@ -2504,6 +2504,7 @@ sub build_spatial_index {    #  builds GROUPS, not LABELS
     }
     else {
         $index = Biodiverse::Index->new( %args, element_hash => \%groups );
+        $index->set_basedata_ref_aa($self);
         $self->set_param( SPATIAL_INDEX => $index );
     }
 

--- a/lib/Biodiverse/BaseData/FeatureData.pm
+++ b/lib/Biodiverse/BaseData/FeatureData.pm
@@ -103,7 +103,7 @@ sub _get_rotated_scaled_axis_coords_hash {
 
     my $angle = ($args{angle} // 0);
 
-    my $cache  = $self->get_cached_value_dor_set_default_href ('get_rotated_axis_coords_hash');
+    my $cache  = $self->get_cached_value_dor_set_default_href ('_get_rotated_scaled_axis_coords_hash');
     $cache     = $cache->{join ':', @axes} //= {};
     my $cached_hash = $cache->{$angle};
     return $cached_hash if $cached_hash;

--- a/lib/Biodiverse/BaseData/FeatureData.pm
+++ b/lib/Biodiverse/BaseData/FeatureData.pm
@@ -1,0 +1,98 @@
+package Biodiverse::BaseData::FeatureData;
+use strict;
+use warnings;
+use 5.036;
+
+our $VERSION = '5.0';
+
+use experimental qw /refaliasing declared_refs/;
+use Geo::GDAL::FFI;
+use Carp qw /croak/;
+
+sub get_groups_as_geopackage {
+    my ($self, %args) = @_;
+
+    my @res = $self->get_cell_sizes;
+    \my @axes = $args{axes} // [0,1];
+
+    croak "Cannot calculate geopackage for a single axis"
+        if @res == 1;
+    croak "Cannot calculate geopackage for text axes"
+        if $res[$axes[0]] < 0 || $res[$axes[1]] < 0;
+
+    my $as_points = $args{as_points} // $args{as_point};
+
+    croak "Cannot calculate geopackage for point axes"
+        if $res[$axes[0]] == 0 || $res[$axes[1]] == 0;
+
+    my $geometry_type = $as_points ? 'Point' : 'Polygon';
+
+    my $cache_key = "${geometry_type}_axes_" . join ':', @axes;
+
+    #  use the volatile cache to avoid issues with serialisation and GDAL objects
+    my $vcache = $self->get_volatile_cache;
+    my $cached_data = $vcache->get_cached_value_dor_set_default_href ('GROUP_COORDS_AS_GEOPACKAGE');
+
+    if (my $cached = $cached_data->{$cache_key}) {
+        return $cached;
+    }
+
+    \my @gp_names = $self->get_groups;
+    my $gp = $self->get_groups_ref;
+
+    my $ds_name = "/vsimem/BASEDATA_GROUPS_${self}.gpkg";
+    my $gpkg
+        = Geo::GDAL::FFI::GetDriver('GPKG')->Create ($ds_name);
+    my $layer = $gpkg->CreateLayer({
+        Name => ('group_coords_axes_'. join '_', @axes),
+        GeometryType => $geometry_type,
+        Options => {SPATIAL_INDEX => 'YES'},
+        Fields => [
+            {Name => 'ELEMENT', Type => 'String'},
+            {Name => 'Axis0',   Type => 'Real'},
+            {Name => 'Axis1',   Type => 'Real'},
+        ],
+    });
+
+    my ($cx, $cy) = ($res[0] / 2, $res[1] / 2);
+
+    if (!@gp_names) {
+        my $wkt = $as_points ? "POINT EMPTY" : "POLYGON EMPTY";
+        my $g = Geo::GDAL::FFI::Geometry->new(WKT => $wkt);
+        my $f = Geo::GDAL::FFI::Feature->new($layer->GetDefn);
+        $f->SetGeomField($g);
+        $layer->CreateFeature($f);
+    }
+    else {
+        foreach my $name (@gp_names) {
+            my $coords = $gp->get_element_name_as_array_aa($name);
+            my ($x, $y) = @$coords[@axes];
+            my $wkt;
+            if ($as_points) {
+                $wkt = "POINT ($x $y)";
+            }
+            else {
+                $wkt = sprintf(
+                    "POLYGON ((%s %s, %s %s, %s %s, %s %s, %s %s))",
+                    $x-$cx, $y-$cy,
+                    $x-$cx, $y+$cy,
+                    $x+$cx, $y+$cy,
+                    $x+$cx, $y-$cy,
+                    $x-$cx, $y-$cy,
+                );
+            }
+            my $g = Geo::GDAL::FFI::Geometry->new(WKT => $wkt);
+            my $f = Geo::GDAL::FFI::Feature->new($layer->GetDefn);
+            $f->SetGeomField($g);
+            $f->SetField(ELEMENT => $name);
+            $f->SetField(Axis0 => $x);
+            $f->SetField(Axis1 => $y);
+            $layer->CreateFeature($f);
+        }
+    }
+
+    return $cached_data->{$cache_key} = $gpkg;
+}
+
+
+1;

--- a/lib/Biodiverse/Index.pm
+++ b/lib/Biodiverse/Index.pm
@@ -589,17 +589,11 @@ sub predict_offsets {  #  predict the maximum spatial distances needed to search
 
         #  loop over the 3x3 nbrs of the extreme element
         foreach my $check_element (@{$element_search_list{$extreme_element}}) {  
-            my $check_ref;
-            if (defined $index_element_arrays{$check_element}) {
-                $check_ref = $index_element_arrays{$check_element};
-            }
-            else {
-                $check_ref = $self->csv2list(
+            my $check_ref = $index_element_arrays{$check_element}
+                // $self->csv2list(
                     string     => $check_element,
                     csv_object => $csv_object,
                 );
-                $index_element_arrays{$check_element} = $check_ref;  #  store it
-            }
 
             #  update progress to GUI
             $count ++;
@@ -616,17 +610,11 @@ sub predict_offsets {  #  predict the maximum spatial distances needed to search
                 #   to see if they pass the conditions
 
                 #  get it as an array ref
-                my $element_ref;
-                if (defined $index_element_arrays{$element}) {
-                    $element_ref  = $index_element_arrays{$element};
-                }
-                else {
-                    $element_ref = $self->csv2list (
+                my $element_ref = $index_element_arrays{$element}
+                    // $self->csv2list (
                         string => $element,
                         csv_object => $csv_object,
                     );
-                    $index_element_arrays{$element} = $element_ref;  #  store it
-                }
 
                 #  get the correct offset (we are assessing the corners of the one we want)
                 # need to snap to precision of the original index

--- a/lib/Biodiverse/Index.pm
+++ b/lib/Biodiverse/Index.pm
@@ -460,11 +460,6 @@ sub predict_offsets {  #  predict the maximum spatial distances needed to search
         $index_res_precision[$i] = $decimal_len ? (10 ** $decimal_len) : undef;
     }
 
-    my $subset_search_offsets;
-    my $extreme_elements_ref;
-    my $use_subset_search = $args{index_use_subset_search};
-    my $using_cell_units  = undef;
-    my $subset_dist       = $args{index_search_dist};
     #  insert a shortcut for no neighbours
     if ($spatial_conditions->get_result_type eq 'self_only') {
         my $off_array = [(0) x scalar @$index_resolutions];  #  all zeroes
@@ -476,7 +471,8 @@ sub predict_offsets {  #  predict the maximum spatial distances needed to search
         say "Done (and what's more I cheated)";
         return wantarray ? %valid_offsets : \%valid_offsets;
     }
-    
+
+    my $extreme_elements_ref;
     my $index_max_search_dist = $spatial_conditions->get_index_max_dist;
     if ($index_max_search_dist) {
         my $max_off = $self->round_up_to_resolution (values => $index_max_search_dist);
@@ -495,7 +491,6 @@ sub predict_offsets {  #  predict the maximum spatial distances needed to search
             maxima      => $max_off,
             resolutions => $index_resolutions,
             precision   => \@index_res_precision,
-            #sep_char    => $sep_char,
         );
         if (   $spatial_conditions->get_shape_type ne 'square'
             && $index_max_search_dist > 2 * List::Util::min (@$index_resolutions)
@@ -573,7 +568,6 @@ sub predict_offsets {  #  predict the maximum spatial distances needed to search
     #  works from the eight neighbours of each corner to ensure we allow for data elements near the index boundaries.
     #  Keeps a track of those offsets that have already passed so it does not need to check them again.
     my %valid_index_offsets;
-    my (@min_offset, @max_offset);
 
     my $progress_bar = Biodiverse::Progress->new();
     my $to_do = $total_elements_to_search;

--- a/lib/Biodiverse/Spatial.pm
+++ b/lib/Biodiverse/Spatial.pm
@@ -871,6 +871,11 @@ sub sp_calc {
                   . "Index will be ignored for neighbour set $set_i.";
                 next SPATIAL_PARAMS_LOOP;
             }
+            elsif ($result_type eq 'side') {
+                say "[SPATIAL] Sidedness condition used.  "
+                    . "Index will be ignored for neighbour set $set_i.";
+                next SPATIAL_PARAMS_LOOP;
+            }
             elsif ($ignore_index
                    || $result_type eq 'always_false'
                    || $sp_cond_obj->get_param ('INDEX_NO_USE')) {
@@ -878,9 +883,8 @@ sub sp_calc {
                 say "[SPATIAL] Index set to be ignored for neighbour set $set_i.";
                 next SPATIAL_PARAMS_LOOP;
             }
-            else {
-                say "[SPATIAL] Result type for neighbour set $set_i is $result_type."
-            }
+
+            say "[SPATIAL] Result type for neighbour set $set_i is $result_type.";
 
             my $search_blocks = $search_blocks_arr->[$i];
 

--- a/t/22-SpatialConditions3.t
+++ b/t/22-SpatialConditions3.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use 5.036;
 use Carp;
 use English qw{
     -no_match_vars
@@ -108,7 +109,7 @@ sub test_case {
     }
 
     is scalar keys %$neighbours, $count,
-       'The correct amount of neighbours was returned';
+       qq{The correct number of neighbours was returned for $cond"};
 
     verify_set_contents (
         set      => $neighbours,


### PR DESCRIPTION
Makes the `sp_is_left_of`, `sp_is_right_of` and `sp_in_line_with` methods  faster by using a cache of rotated coordinates and better use of the spatial index.  

Fixes #1061 