### PR TITLE
Spatial conditions: a better way of stripping whitespace

### DIFF
--- a/lib/Biodiverse/SpatialConditions.pm
+++ b/lib/Biodiverse/SpatialConditions.pm
@@ -253,12 +253,56 @@ sub get_conditions_nws {
     $conditions = $self->get_param('PARSED_CONDITIONS');
     croak "Conditions have not been parsed\n" if !defined $conditions;
 
-    $conditions = $conditions =~ s/ (?&PerlNWS) $PPR::GRAMMAR//gxr;
-
+    # $conditions = $conditions =~ s/ (?&PerlNWS) $PPR::GRAMMAR//gxr;
+    $conditions = $self->_remove_whitespace_from_code($conditions);
     $self->set_cached_value ($cache_key => $conditions);
 
     return $conditions;
 }
+
+sub _remove_whitespace_from_code {
+    my ($self, $code) = @_;
+    state $re_quotelike = qr/
+        \bmy\b\s+ |  #  "my $x...$" is otherwise treated as "m y$x...$"
+        (?&PerlVariableScalar)?  #  avoid $y getting similar treatment
+        (?<quoted>
+             (?: (?<! [\$\@%]) (?&PerlQuotelike) )
+             | (?&PerlHashIndexer)
+             | (?: \s not \s)
+             | (?: \s (?&PerlLowPrecedenceInfixOperator) \s)
+        )
+        $PPR::GRAMMAR
+    /x;
+
+    #  find the whitespace that is not in quotes or quotelike code
+    my @to_change;
+    while ($code =~ /$re_quotelike/gx) {
+        next if !defined $+{quoted};
+        my $from = $+{quoted};
+        #  whitespace to char 034 as \s does not match it
+        my $to = $from =~ s/\s/\034/gr; #  could map chars using tr///
+        push @to_change, [ $from, $to ];
+    }
+
+    #  replace the quotelike parts
+    my $code2 = $code;
+    foreach my $pair (@to_change) {
+        my ($from, $to) = @$pair;
+        $code2 =~ s/\Q$from\E/$to/;
+    }
+
+    #  strip whitespace
+    $code2 =~ s/(?&PerlOWS) $PPR::GRAMMAR//gx;
+
+    #  put the quotelike code back
+    foreach my $pair (@to_change) {
+        my ($orig, $now) = @$pair;
+        $code2 =~ s/\Q$now\E/$orig/;
+    }
+
+    return $code2;
+}
+
 
 sub has_conditions {
     my $self       = shift;
@@ -491,8 +535,8 @@ sub parse_distances {
                 }
             }
 
-            #  should only use compacted version but need to check other uses first
-            my $compacted_sub_name_and_args = $sub_name_and_args =~ s/(?&PerlNWS) $PPR::GRAMMAR//grx;
+            #  should perhaps only use compacted version but need to check other uses first
+            my $compacted_sub_name_and_args = $self->_remove_whitespace_from_code($sub_name_and_args);
             $method_args{$compacted_sub_name_and_args} = \%hash_1;
 
             my $invalid = $self->get_invalid_args_for_sub_call (sub => $sub, args => \%hash_1);
@@ -627,11 +671,10 @@ sub parse_distances {
     #print $conditions;
     $self->set_param( PARSED_CONDITIONS => $conditions );
 
-    my $conditions_nws = $self->get_conditions_nws;
-
     my $substitute_method;
     foreach my $metadata (@substitute_methods_to_check) {
         my $re = $self->get_regex (name => $metadata->{re_name});
+        my $conditions_nws = $self->get_conditions_nws;
         if ($conditions_nws =~ $re) {
             $substitute_method = $metadata->{method};
         }

--- a/t/22-SpatialConditions-main.t
+++ b/t/22-SpatialConditions-main.t
@@ -1,3 +1,4 @@
+use 5.036;
 use strict;
 use warnings;
 use Carp;
@@ -72,6 +73,8 @@ exit main( @ARGV );
 sub main {
     my @args  = @_;
 
+    test_remove_whitespace_from_code();
+
     test_overload();
     test_clone();
 
@@ -99,6 +102,62 @@ sub main {
     done_testing;
     return 0;
 }
+
+sub test_remove_whitespace_from_code {
+    my $sc = Biodiverse::SpatialConditions->new(conditions => '1');
+
+    {
+        my $base_code = <<~'EOC'
+            !     $self->sp_point_in_poly_shape(
+               file => qq'C:\a \b \c .shp' ,
+               buffer => 10
+              );
+              my $x = my $y =     1;
+              my $z=$x and not $y;
+              my %h;$h{a b c} = 5;
+            EOC
+        ;
+        my $exp = <<'EOC'
+!$self->sp_point_in_poly_shape(file=>qq'C:\a \b \c .shp',buffer=>10);
+my$x=my$y=1;my$z=$x and not$y;
+my%h;$h{a b c}=5;
+EOC
+;
+        $exp = join '', split /[\n\r]+/, $exp;
+        my $got = $sc->_remove_whitespace_from_code($base_code);
+        is $got, $exp, 'strip WS, complex case';
+    }
+
+    {
+        my $base_code = <<~'EOC'
+          !   $self->sp_point_in_poly_shape(
+           file => qq'C:\a \b \c .shp' ,
+           buffer => 10
+          );
+        EOC
+        ;
+        my $exp = <<'EOC'
+!$self->sp_point_in_poly_shape(file=>qq'C:\a \b \c .shp',buffer=>10);
+EOC
+;
+        $exp = join '', split /[\n\r]+/, $exp;
+        my $got = $sc->_remove_whitespace_from_code($base_code);
+        is $got, $exp, 'strip WS, less complex case';
+    }
+
+    {
+        my $base_code = <<~'EOC'
+              my $x = my $y =     1;
+              my $z=$x and not $y;
+              my %h;$h{a b c} = 5;
+            EOC
+        ;
+        my $exp = 'my$x=my$y=1;my$z=$x and not$y;my%h;$h{a b c}=5;';
+        my $got = $sc->_remove_whitespace_from_code($base_code);
+        is $got, $exp, 'strip WS from variables';
+    }
+}
+
 
 sub test_overload {
     my $cond = 'sp_self_only()';


### PR DESCRIPTION
The previous approach did not account for quoted text and other quote-like constructs.

Only call the non-whitespace conditions when needed. This saves a smidgen of time.