### PR TITLE
CI updates, 2026-03-26

### DIFF
--- a/.github/workflows/linux_de_locale.yml
+++ b/.github/workflows/linux_de_locale.yml
@@ -17,6 +17,7 @@ env:
   #LC_NUMERIC: de_DE.iso88591
   #LC_CTYPE: de_DE.iso88591
   MAKEFLAGS: -j4
+  PERL_CPANM_OPT: '-M https://cpan.metacpan.org/ --metacpan'
 
 jobs:
   perl:
@@ -62,7 +63,7 @@ jobs:
       - name: Prepare for cache
         run: |
           perl -V > perlversion.txt
-          echo '20221210' >> perlversion.txt
+          echo '20260326' >> perlversion.txt
           ls -l perlversion.txt
 
       - name: Cache CPAN modules
@@ -83,6 +84,7 @@ jobs:
           #eval $(perl -I ${PERL_MOD_DIR}/lib/perl5/ -Mlocal::lib)
           # https://github.com/libwww-perl/libwww-perl/issues/491
           cpanm --notest LWP
+          cpanm --notest XML::Twig
           cpanm --installdeps FFI::Platypus
           cpanm --notest FFI::Platypus
           #cpanm --notest FFI::Platypus::Declare

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,6 +13,7 @@ env:
   PERL_LOCAL_LIB_ROOT: /Users/runner/perl5
   PERL_MB_OPT: --install_base /Users/runner/perl5
   PERL_MM_OPT: INSTALL_BASE=/Users/runner/perl5
+  PERL_CPANM_OPT: '-M https://cpan.metacpan.org/ --metacpan'
 
 jobs:
   perl:
@@ -50,7 +51,7 @@ jobs:
       - name: Prepare for cache
         run: |
           perl -V > perlversion.txt
-          echo '20241125' >> perlversion.txt
+          echo '20260326' >> perlversion.txt
           ls -l perlversion.txt
 
       - name: Cache CPAN modules


### PR DESCRIPTION
Use metacpan mirror as cpan.org is having issues at the moment.

No tests for XML::Twig due to unrelated failures.