### PR TITLE
Raster imports pdl: use RLE and other speedups

### DIFF
--- a/lib/Biodiverse/BaseData/Import.pm
+++ b/lib/Biodiverse/BaseData/Import.pm
@@ -936,8 +936,16 @@ sub import_data_raster {
                                 my $vals   = $subset->where ($subset->isgood);
                                 next CELL_ID if $vals->nelem == 0;
 
+                                my ($rle_n, $rle_v) = $vals->qsort->rle;
+
                                 my %val_hash;
-                                $val_hash{$_}++ for $vals->list;
+                                if ($rle_v->nelem == $vals->nelem) {
+                                    #  all unique vals so directly assign
+                                    @val_hash{$vals->list} = (1) x $vals->nelem;
+                                }
+                                else {
+                                    @val_hash{$rle_v->list} = $rle_n->list;
+                                }
 
                                 my $gp_col = $c_id % $nbinx;
                                 my $gp_row = ($c_id - $gp_col) / $nbinx;

--- a/lib/Biodiverse/BaseData/Import.pm
+++ b/lib/Biodiverse/BaseData/Import.pm
@@ -858,31 +858,22 @@ sub import_data_raster {
                             $ybd_min,  $ybd_max,
                             $xgeo_min, $xgeo_max,
                             $ygeo_min, $ygeo_max,
-                            $xcoords,  $ycoords,
                         );
+                        my $w0 = $wpos + 0.5;
+                        my $w1 = $w0 + $nx - 1;
+                        my $h0 = $hpos + 0.5;
+                        my $h1 = $h0 + $ny - 1;
+
+                        my $xcoords = $z->xlinvals($w0 * $tf_xx + $tf_x0, $w1 * $tf_xx + $tf_x0);
+                        my $ycoords = $z->ylinvals($h0 * $tf_yy + $tf_y0, $h1 * $tf_yy + $tf_y0);
+
                         if (!$tf_xy && !$tf_yx) {  #   axis-aligned raster so simpler approach
-                            my $xgeo_minn = ($wpos + 0.5) * $tf_xx + $tf_x0;
-                            my $xgeo_maxx =  $xgeo_minn + $tf_xx * ($nx - 1);
-                            $xcoords = $z->xlinvals($xgeo_minn, $xgeo_maxx);
-
-                            my $ygeo_minn = ($hpos + 0.5) * $tf_yy + $tf_y0;
-                            my $ygeo_maxx =  $ygeo_minn + $tf_yy * ($ny - 1);
-                            $ycoords = $z->ylinvals($ygeo_minn, $ygeo_maxx);
-
                             #  use minmax as order could be reversed, e.g. for many y-axes
-                            ($xgeo_min, $xgeo_max) = List::MoreUtils::minmax ($xgeo_minn, $xgeo_maxx);
-                            ($ygeo_min, $ygeo_max) = List::MoreUtils::minmax ($ygeo_minn, $ygeo_maxx);
+                            ($xgeo_min, $xgeo_max) = List::MoreUtils::minmax ($xcoords->at(0,0), $xcoords->at(-1,-1));
+                            ($ygeo_min, $ygeo_max) = List::MoreUtils::minmax ($ycoords->at(0,0), $ycoords->at(-1,-1));
                         }
                         else {
-                            my $w0 = $wpos + 0.5;
-                            my $w1 = $w0 + $nx - 1;
-                            my $h0 = $hpos + 0.5;
-                            my $h1 = $h0 + $ny - 1;
-
-                            $xcoords = $z->xlinvals($w0 * $tf_xx + $tf_x0, $w1 * $tf_xx + $tf_x0);
-                            $ycoords = $z->ylinvals($h0 * $tf_yy + $tf_y0, $h1 * $tf_yy + $tf_y0);
-
-                            #  now skew them if needed
+                            #  skew them if needed
                             $xcoords  += $z->ylinvals($h0 * $tf_xy, $h1 * $tf_xy) if $tf_xy;
                             $ycoords  += $z->xlinvals($w0 * $tf_yx, $w1 * $tf_yx) if $tf_yx;
 

--- a/lib/Biodiverse/BaseData/Import.pm
+++ b/lib/Biodiverse/BaseData/Import.pm
@@ -14,7 +14,7 @@ use Carp;
 use POSIX qw {fmod floor ceil log2};
 use Scalar::Util qw /looks_like_number blessed reftype/;
 use List::Util 1.45 qw /max min sum any all none notall pairs uniq/;
-use List::MoreUtils qw /first_index/;
+use List::MoreUtils qw /first_index minmax/;
 use Path::Tiny qw /path/;
 use Geo::Converter::dms2dd qw {dms2dd};
 use Regexp::Common qw /number/;
@@ -852,8 +852,6 @@ sub import_data_raster {
                             $nx,   $ny,
                         );
 
-                        my $zeroes = $z->zeroes;
-
                         my (
                             $nbinx,    $nbiny,
                             $xbd_min,  $xbd_max,
@@ -863,14 +861,17 @@ sub import_data_raster {
                             $xcoords,  $ycoords,
                         );
                         if (!$tf_xy && !$tf_yx) {  #   axis-aligned raster so simpler approach
-                            my $xgeo = $z->sequence($nx)->inplace->plus($wpos + 0.5)->mult($tf_xx)->plus($tf_x0);
-                            my $ygeo = $z->sequence($ny)->inplace->plus($hpos + 0.5)->mult($tf_yy)->plus($tf_y0);
+                            my $xgeo_minn = ($wpos + 0.5) * $tf_xx + $tf_x0;
+                            my $xgeo_maxx =  $xgeo_minn + $tf_xx * ($nx - 1);
+                            $xcoords = $z->xlinvals($xgeo_minn, $xgeo_maxx);
 
-                            ($xgeo_min, $xgeo_max) = List::MoreUtils::minmax($xgeo->at(0), $xgeo->at(-1));
-                            ($ygeo_min, $ygeo_max) = List::MoreUtils::minmax($ygeo->at(0), $ygeo->at(-1));
+                            my $ygeo_minn = ($hpos + 0.5) * $tf_yy + $tf_y0;
+                            my $ygeo_maxx =  $ygeo_minn + $tf_yy * ($ny - 1);
+                            $ycoords = $z->ylinvals($ygeo_minn, $ygeo_maxx);
 
-                            $xcoords = $zeroes->plus($xgeo);
-                            $ycoords = $zeroes->plus($ygeo->transpose),
+                            #  use minmax as order could be reversed, e.g. for many y-axes
+                            ($xgeo_min, $xgeo_max) = List::MoreUtils::minmax ($xgeo_minn, $xgeo_maxx);
+                            ($ygeo_min, $ygeo_max) = List::MoreUtils::minmax ($ygeo_minn, $ygeo_maxx);
                         }
                         else {
                             my $xvals = $z->xvals->plus($wpos + 0.5);
@@ -936,7 +937,7 @@ sub import_data_raster {
                                 my $vals   = $z->badflag
                                     ? $subset->where ($subset->isgood)
                                     : $subset;
-                                
+
                                 next CELL_ID if $vals->nelem == 0;
 
                                 my $gp_col = $c_id % $nbinx;

--- a/lib/Biodiverse/BaseData/Import.pm
+++ b/lib/Biodiverse/BaseData/Import.pm
@@ -901,8 +901,8 @@ sub import_data_raster {
                                 $xcoords->flat,
                                 $ycoords->flat,
                                 $z->flat->setnonfinitetobad->setbadtoval(0),
-                                $cellsize_e, $xbd_min - ($cellsize_e / 2), $nbinx,
-                                $cellsize_n, $ybd_min - ($cellsize_n / 2), $nbiny,
+                                $cellsize_e, $xbd_min - $halfcellsize_e, $nbinx,
+                                $cellsize_n, $ybd_min - $halfcellsize_n, $nbiny,
                             );
 
                             my $indices = $aggregated->whichND;
@@ -918,8 +918,14 @@ sub import_data_raster {
                         }
                         else {
                             #  inplace because we do not use them beyond this block
-                            my $bd_col   = $xcoords->inplace->minus($xbd_min - $halfcellsize_e)->divide($cellsize_e)->floor;
-                            my $bd_row   = $ycoords->inplace->minus($ybd_min - $halfcellsize_n)->divide($cellsize_n)->floor;
+                            my $bd_col = $xcoords;
+                            my $bd_row = $ycoords;
+                            $bd_col -= ($xbd_min - $halfcellsize_e);
+                            $bd_col /= $cellsize_e;
+                            $bd_col->inplace->floor;
+                            $bd_row -= ($ybd_min - $halfcellsize_n);
+                            $bd_row /= $cellsize_n;
+                            $bd_row->inplace->floor;
                             my $cell_ids = $bd_col + $bd_row * $nbinx;
 
                             #  faster than extracting from $cell_ids

--- a/lib/Biodiverse/BaseData/Import.pm
+++ b/lib/Biodiverse/BaseData/Import.pm
@@ -858,21 +858,31 @@ sub import_data_raster {
                             $ybd_min,  $ybd_max,
                             $xgeo_min, $xgeo_max,
                             $ygeo_min, $ygeo_max,
+                            $xcoords,  $ycoords,
                         );
                         my $w0 = $wpos + 0.5;
                         my $w1 = $w0 + $nx - 1;
                         my $h0 = $hpos + 0.5;
                         my $h1 = $h0 + $ny - 1;
 
-                        my $xcoords = $z->xlinvals($w0 * $tf_xx + $tf_x0, $w1 * $tf_xx + $tf_x0);
-                        my $ycoords = $z->ylinvals($h0 * $tf_yy + $tf_y0, $h1 * $tf_yy + $tf_y0);
 
                         if (!$tf_xy && !$tf_yx) {  #   axis-aligned raster so simpler approach
+                            #  calc for one row or col, then broadcast
+                            $xcoords = PDL->zeroes($nx)->xlinvals($w0 * $tf_xx + $tf_x0, $w1 * $tf_xx + $tf_x0);
+                            $ycoords = PDL->zeroes($ny)->transpose->ylinvals($h0 * $tf_yy + $tf_y0, $h1 * $tf_yy + $tf_y0);
+
                             #  use minmax as order could be reversed, e.g. for many y-axes
-                            ($xgeo_min, $xgeo_max) = List::MoreUtils::minmax ($xcoords->at(0,0), $xcoords->at(-1,-1));
-                            ($ygeo_min, $ygeo_max) = List::MoreUtils::minmax ($ycoords->at(0,0), $ycoords->at(-1,-1));
+                            ($xgeo_min, $xgeo_max) = List::MoreUtils::minmax ($xcoords->at(0), $xcoords->at(-1));
+                            ($ygeo_min, $ygeo_max) = List::MoreUtils::minmax ($ycoords->at(0,0), $ycoords->at(0,-1));
+
+                            my $zeroes = $z->zeroes;
+                            $xcoords = $zeroes + $xcoords;
+                            $ycoords = $zeroes + $ycoords;
                         }
                         else {
+                            $xcoords = $z->xlinvals($w0 * $tf_xx + $tf_x0, $w1 * $tf_xx + $tf_x0);
+                            $ycoords = $z->ylinvals($h0 * $tf_yy + $tf_y0, $h1 * $tf_yy + $tf_y0);
+
                             #  skew them if needed
                             $xcoords  += $z->ylinvals($h0 * $tf_xy, $h1 * $tf_xy) if $tf_xy;
                             $ycoords  += $z->xlinvals($w0 * $tf_yx, $w1 * $tf_yx) if $tf_yx;

--- a/lib/Biodiverse/BaseData/Import.pm
+++ b/lib/Biodiverse/BaseData/Import.pm
@@ -936,17 +936,6 @@ sub import_data_raster {
                                 my $vals   = $subset->where ($subset->isgood);
                                 next CELL_ID if $vals->nelem == 0;
 
-                                my ($rle_n, $rle_v) = $vals->qsort->rle;
-
-                                my %val_hash;
-                                if ($rle_v->nelem == $vals->nelem) {
-                                    #  all unique vals so directly assign
-                                    @val_hash{$vals->list} = (1) x $vals->nelem;
-                                }
-                                else {
-                                    @val_hash{$rle_v->list} = $rle_n->list;
-                                }
-
                                 my $gp_col = $c_id % $nbinx;
                                 my $gp_row = ($c_id - $gp_col) / $nbinx;
 
@@ -954,14 +943,23 @@ sub import_data_raster {
                                     $xbd_min + $gp_col * $cellsize_e,
                                     $ybd_min + $gp_row * $cellsize_n;
 
-                                if (%catname_hash) {
-                                    my %cats = map {
-                                        ($catname_hash{$_} // $_) => $val_hash{$_}
-                                    } keys %val_hash;
-                                    $gp_lb_hash{$gp} = \%cats;
+                                my ($rle_n, $rle_v) = $vals->qsort->rle;
+
+                                my @idx  = $rle_n->list;
+                                my @vals = $rle_v->list;
+                                if (keys %catname_hash) {
+                                    @vals = map {$catname_hash{$_} // $_} @vals;
+                                }
+
+                                \my %val_hash = $gp_lb_hash{$gp} //= {};
+                                if (%val_hash) {
+                                    #  already have data so increment each key
+                                    $val_hash{$vals[$_]} += $idx[$_]
+                                        for 0 .. $#vals;
                                 }
                                 else {
-                                    $gp_lb_hash{$gp} = \%val_hash;
+                                    #  clean slate so slice-assign
+                                    @val_hash{@vals} = @idx;
                                 }
                             }
                         }

--- a/lib/Biodiverse/BaseData/Import.pm
+++ b/lib/Biodiverse/BaseData/Import.pm
@@ -926,7 +926,8 @@ sub import_data_raster {
                             $bd_row -= ($ybd_min - $halfcellsize_n);
                             $bd_row /= $cellsize_n;
                             $bd_row->inplace->floor;
-                            my $cell_ids = $bd_col + $bd_row * $nbinx;
+                            $bd_row *= $nbinx;
+                            my $cell_ids = $bd_col += $bd_row;
 
                             #  faster than extracting from $cell_ids
                             my $max_id = POSIX::floor (($xbd_max - $xbd_min) / $cellsize_e)

--- a/lib/Biodiverse/BaseData/Import.pm
+++ b/lib/Biodiverse/BaseData/Import.pm
@@ -874,10 +874,17 @@ sub import_data_raster {
                             ($ygeo_min, $ygeo_max) = List::MoreUtils::minmax ($ygeo_minn, $ygeo_maxx);
                         }
                         else {
-                            my $xvals = $z->xvals->plus($wpos + 0.5);
-                            my $yvals = $z->yvals->plus($hpos + 0.5);
-                            $xcoords  = $xvals->mult($tf_xx)->plus($yvals->mult($tf_xy)->plus($tf_x0));
-                            $ycoords  = $yvals->mult($tf_yy)->plus($xvals->mult($tf_yx)->plus($tf_y0));
+                            my $w0 = $wpos + 0.5;
+                            my $w1 = $w0 + $nx - 1;
+                            my $h0 = $hpos + 0.5;
+                            my $h1 = $h0 + $ny - 1;
+
+                            $xcoords = $z->xlinvals($w0 * $tf_xx + $tf_x0, $w1 * $tf_xx + $tf_x0);
+                            $ycoords = $z->ylinvals($h0 * $tf_yy + $tf_y0, $h1 * $tf_yy + $tf_y0);
+
+                            #  now skew them if needed
+                            $xcoords  += $z->ylinvals($h0 * $tf_xy, $h1 * $tf_xy) if $tf_xy;
+                            $ycoords  += $z->xlinvals($w0 * $tf_yx, $w1 * $tf_yx) if $tf_yx;
 
                             my $idx_extrema = PDL->new(PDL::indx, [[0,0],[0,$ny-1],[$nx-1,0],[$nx-1,$ny-1]]);
 

--- a/lib/Biodiverse/BaseData/Import.pm
+++ b/lib/Biodiverse/BaseData/Import.pm
@@ -876,21 +876,18 @@ sub import_data_raster {
                         else {
                             my $xvals = $z->xvals->plus($wpos + 0.5);
                             my $yvals = $z->yvals->plus($hpos + 0.5);
-                            my $xgeo  = $xvals->mult($tf_xx)->plus($yvals->mult($tf_xy)->plus($tf_x0));
-                            my $ygeo  = $yvals->mult($tf_yy)->plus($xvals->mult($tf_yx)->plus($tf_y0));
+                            $xcoords  = $xvals->mult($tf_xx)->plus($yvals->mult($tf_xy)->plus($tf_x0));
+                            $ycoords  = $yvals->mult($tf_yy)->plus($xvals->mult($tf_yx)->plus($tf_y0));
 
                             my $idx_extrema = PDL->new(PDL::indx, [[0,0],[0,$ny-1],[$nx-1,0],[$nx-1,$ny-1]]);
 
-                            my $extrema_x = $xgeo->indexND($idx_extrema);
+                            my $extrema_x = $xcoords->indexND($idx_extrema);
                             $xgeo_min = $extrema_x->min;
                             $xgeo_max = $extrema_x->max;
 
-                            my $extrema_y = $ygeo->indexND($idx_extrema);
+                            my $extrema_y = $ycoords->indexND($idx_extrema);
                             $ygeo_min = $extrema_y->min;
                             $ygeo_max = $extrema_y->max;
-
-                            $xcoords = $xgeo;
-                            $ycoords = $ygeo;
                         }
 
                         $xbd_min = bd_cell_snapper($xgeo_min, $cellorigin_e, $cellsize_e);

--- a/lib/Biodiverse/BaseData/Import.pm
+++ b/lib/Biodiverse/BaseData/Import.pm
@@ -933,7 +933,10 @@ sub import_data_raster {
                             CELL_ID:
                             foreach my $c_id (0 .. $max_id) {
                                 my $subset = $z->where($cell_ids == $c_id);
-                                my $vals   = $subset->where ($subset->isgood);
+                                my $vals   = $z->badflag
+                                    ? $subset->where ($subset->isgood)
+                                    : $subset;
+                                
                                 next CELL_ID if $vals->nelem == 0;
 
                                 my $gp_col = $c_id % $nbinx;


### PR DESCRIPTION
Use of Run Length Encoding avoids many repeated hash lookups for the same key.

xlinvals and ylinvals runs some calculations inside PDL instead of across variables