### PR TITLE
Refactor the node range hash caching

### DIFF
--- a/lib/Biodiverse/Analyses.pm
+++ b/lib/Biodiverse/Analyses.pm
@@ -1,0 +1,42 @@
+#  base class for analyses to inherit from
+package Biodiverse::Analyses;
+use strict;
+use warnings;
+use 5.036;
+
+our $VERSION = '5.0';
+
+#  Keying by sha allows more general re-use by other code,
+#  e.g. derived eq length trees have the same topology.
+#  Such ranges are invariant for this basedata.
+sub _get_cached_node_range_table_aa {
+    my ($self, $tree, $want_lists) = @_;
+
+    return if !defined $tree;
+
+    my $cache = $self->get_cached_href ('get_node_range_hash');
+    return if !keys %$cache;
+
+    my $type = $want_lists ? 'return_lists' : 'return_scalars';
+
+    my $sha = $tree->get_sha256_topology;
+
+    no autovivification;
+    return $cache->{$sha}{$type};
+}
+
+sub _set_cached_node_range_table_aa {
+    my ($self, $href, $tree, $want_lists) = @_;
+
+    return if !defined $tree;
+
+    my $cache = $self->get_cached_href ('get_node_range_hash');
+
+    my $type = $want_lists ? 'return_lists' : 'return_scalars';
+
+    my $sha = $tree->get_sha256_topology;
+
+    $cache->{$sha}{$type} = $href;
+}
+
+1;

--- a/lib/Biodiverse/Cluster.pm
+++ b/lib/Biodiverse/Cluster.pm
@@ -45,6 +45,7 @@ use Ref::Util qw { :all };
 
 
 use parent qw /
+    Biodiverse::Analyses
     Biodiverse::Tree
     Biodiverse::Common
 /;

--- a/lib/Biodiverse/Indices/Phylogenetic.pm
+++ b/lib/Biodiverse/Indices/Phylogenetic.pm
@@ -1821,7 +1821,6 @@ sub get_node_range_hash {
     my $tree  = $args{trimmed_tree} || croak "Argument trimmed_tree missing\n";
 
     my $return_lists = $args{return_lists};
-    my $rlist_key = $return_lists ? 'return_lists' : 'return_scalars';
 
     if (my $range_hash = $args{node_range_hash}) {
         if (!$return_lists) {
@@ -1838,31 +1837,27 @@ sub get_node_range_hash {
         }
     }
 
-    #  cache on the parent output ref
-    my $output_ref = $self->get_param('OUTPUT_REF') // $self;
-    my $cache = $output_ref->get_cached_href ('get_node_range_hash');
-    my $sha = $tree->get_sha256_topology;
+    #  We cache on the parent output ref.
+    #  No point caching on an unattached indices object - these are mostly in tests.
+    my $output_ref = $self->get_param('OUTPUT_REF');
 
-    #  Keying by sha allows more general re-use by other code,
-    #  e.g. derived eq length trees have the same topology.
-    #  Such ranges are invariant for this basedata.
-    if (my $cached = $cache->{$sha}{$rlist_key}) {
-        my %results = (node_range => $cached);
-        return wantarray ? %results : \%results;
-    }
-    {
+    if ($output_ref) {
+        if (my $cached = $output_ref->_get_cached_node_range_table_aa($tree, $return_lists)) {
+            my %results = (node_range => $cached);
+            return wantarray ? %results : \%results;
+        }
+
         #  did a sibling output use ranges from the same tree?
         my $bd = $self->get_basedata_ref;
         my @outputs = ($bd->get_spatial_output_refs, $bd->get_cluster_output_refs);
+
         foreach my $oref (grep {$_ ne $output_ref} @outputs) {
-            my $ocache = $oref->get_cached_href ('get_node_range_hash');
-            no autovivification;
-            if (my $cached = $ocache->{$sha}{$rlist_key}) {
-                #  store on ourselves in the event the other analysis is deleted
-                $cache->{$sha}{$rlist_key} = $cached;
-                my %results = (node_range => $cached);
-                return wantarray ? %results : \%results;
-            }
+            my $ocache = $oref->_get_cached_node_range_table_aa($tree, $return_lists);
+            next if !$ocache;
+            #  store on ourselves in the event the other analysis is deleted
+            $output_ref->_set_cached_node_range_table_aa($ocache, $tree, $return_lists);
+            my %results = (node_range => $ocache);
+            return wantarray ? %results : \%results;
         }
     }
 
@@ -1915,9 +1910,11 @@ sub get_node_range_hash {
         }
     }
 
-    $cache->{$sha}{$rlist_key} = \%node_range;
+    my $href = \%node_range;
+    $output_ref->_set_cached_node_range_table_aa ($href, $tree, $return_lists)
+      if $output_ref;
 
-    my %results = (node_range => \%node_range);
+    my %results = (node_range => $href);
 
     return wantarray ? %results : \%results;
 }

--- a/lib/Biodiverse/Randomise.pm
+++ b/lib/Biodiverse/Randomise.pm
@@ -1024,18 +1024,16 @@ sub override_object_analysis_args {
             $made_changes++;
         }
         if ($args{use_orig_bd_node_range_hash} && !defined $new_analysis_args->{node_range_hash}) {
-            my $sha = $tree_ref_used->get_sha256_topology;
             my $bd = $self->get_basedata_ref;
             BY_OUTPUT:
             foreach my $o ($bd->get_cluster_output_refs, $bd->get_spatial_output_refs) {
-                my $cache = $o->get_cached_value('get_node_range_hash');
-                next BY_OUTPUT if !defined $cache;
-                no autovivification;
-                if (my $cached_rhash = $cache->{$sha}{return_scalars}) {
-                    $new_analysis_args->{node_range_hash} = $cached_rhash;
-                    $made_changes++;
-                    last BY_OUTPUT;
-                }
+                my $cached_rhash = $o->_get_cached_node_range_table_aa($tree_ref_used);
+
+                next BY_OUTPUT if !defined $cached_rhash;
+
+                $new_analysis_args->{node_range_hash} = $cached_rhash;
+                $made_changes++;
+                last BY_OUTPUT;
             }
         }
     }

--- a/lib/Biodiverse/Spatial.pm
+++ b/lib/Biodiverse/Spatial.pm
@@ -23,8 +23,10 @@ use Biodiverse::Progress;
 use Biodiverse::Indices;
 
 
-
-use parent qw /Biodiverse::BaseStruct/;
+use parent qw /
+    Biodiverse::BaseStruct
+    Biodiverse::Analyses
+/;
 
 my $EMPTY_STRING = q{};
 

--- a/lib/Biodiverse/Tree.pm
+++ b/lib/Biodiverse/Tree.pm
@@ -3903,7 +3903,7 @@ sub get_most_recent_line_colours {
 sub get_sha256_topology {
     my $self = shift;
 
-    my $cache_name = 'SHA256_TOPOLOGY';
+    state $cache_name = 'SHA256_TOPOLOGY';
     my $cached = $self->get_cached_value ($cache_name);
 
     return $cached if $cached;

--- a/t/27-Spatial.t
+++ b/t/27-Spatial.t
@@ -872,9 +872,7 @@ sub test_node_range_hash {
     };
     ok ($success, 'spatial analysis without node_range_hash arg runs without error');
 
-    #  should have an API to get this
-    my $cached_rhash1 = $sp1->get_cached_href ('get_node_range_hash');
-    my $range_hash1 = $cached_rhash1->{$tree_sha}{return_scalars};
+    my $range_hash1 = $sp1->_get_cached_node_range_table_aa($tree);
 
     my $sp2 = $bd1->add_spatial_output(name => 'sp2');
     $success = eval {
@@ -884,8 +882,7 @@ sub test_node_range_hash {
     };
     ok ($success, 'spatial analysis 2 not passed node_range_hash arg runs without error');
 
-    my $cached_rhash2 = $sp2->get_cached_href ('get_node_range_hash');
-    my $range_hash2 = $cached_rhash2->{$tree_sha}{return_scalars};
+    my $range_hash2 = $sp2->_get_cached_node_range_table_aa($tree);
 
     is $range_hash1, $range_hash2, 'range hash content is the same 1&2';
     is ref $range_hash1, ref $range_hash2, 'range hash refs are the same 1&2';
@@ -901,8 +898,7 @@ sub test_node_range_hash {
     };
     ok ($success, 'spatial analysis passed node_range_hash arg runs without error');
 
-    my $cached_rhash3 = $sp3->get_cached_href ('get_node_range_hash');
-    $range_hash3 = $cached_rhash3->{$tree_sha}{return_scalars};
+    $range_hash3 = $sp3->_get_cached_node_range_table_aa($tree);
 
     is $range_hash3, undef, 'range hash content not cached when passed as an argument';
 


### PR DESCRIPTION
We now use an API call to avoid issues with nested hash refs.

The Biodiverse::Analyses class provides these and is inherited by the various analysis classes.