### PR TITLE
GUI tree slider text box: use the default legend font size

### DIFF
--- a/lib/Biodiverse/GUI/Canvas/Tree.pm
+++ b/lib/Biodiverse/GUI/Canvas/Tree.pm
@@ -544,7 +544,7 @@ sub draw_slider {
         $loc[1] = $draw_size->{y};
 
         $cx->select_font_face("Sans", "normal", "bold");
-        $cx->set_font_size( 12 );
+        $cx->set_font_size( Biodiverse::GUI::Canvas::Legend->get_default_font_size );
         my $margin = 2;
         my @text_extents = map {$cx->text_extents($_)} @text;
         my $width   = max map {$_->{width}} @text_extents;


### PR DESCRIPTION
This allows some user control over it.