### PR TITLE
Don't load Alien::GtkStack when $ENV{BD_NO_ALIEN_GTKSTACK} is true

### DIFF
--- a/lib/Biodiverse/Config.pm
+++ b/lib/Biodiverse/Config.pm
@@ -81,7 +81,8 @@ BEGIN {
         }
     }
     if ($^O =~ /mswin/i) {
-        eval 'use Alien::GtkStack::Windows';
+        eval 'use Alien::GtkStack::Windows'
+          if !$ENV{BD_NO_ALIEN_GTKSTACK};  #  mainly for PAR packing
         if (!$EVAL_ERROR) {
             say "Added Alien::GtkStack::Windows bin dir to path";
             say "GI_TYPELIB_PATH is now $ENV{GI_TYPELIB_PATH}"


### PR DESCRIPTION
This allows it to not be packed for the BiodiverseR engine.