### PR TITLE
GUI clustering: set the focus so the tab gets keyboard focus

### DIFF
--- a/lib/Biodiverse/GUI/Tabs/Clustering.pm
+++ b/lib/Biodiverse/GUI/Tabs/Clustering.pm
@@ -343,6 +343,9 @@ sub new {
     $self->update_tree_menu;
     $self->init_colour_clusters;
 
+    #  a crude way of getting ctl-G to work
+    $self->get_xmlpage_object('txtClusterName')->grab_focus;
+
     say "[Clustering tab] - Loaded tab - Clustering Analysis";
 
     return $self;


### PR DESCRIPTION
Otherwise the control-G shortcut was not working.